### PR TITLE
Feature/44 - 트리 내 프로필 조회 기능 및 Branch 계산 로직 추가

### DIFF
--- a/src/main/java/org/example/tree/domain/branch/converter/BranchConverter.java
+++ b/src/main/java/org/example/tree/domain/branch/converter/BranchConverter.java
@@ -1,0 +1,19 @@
+package org.example.tree.domain.branch.converter;
+
+import org.example.tree.domain.branch.entity.Branch;
+import org.example.tree.domain.profile.entity.Profile;
+import org.example.tree.domain.tree.entity.Tree;
+import org.springframework.stereotype.Component;
+
+@Component
+public class BranchConverter {
+
+    public Branch toBranch(Tree tree, Profile inviter, Profile invitee) {
+        return Branch.builder()
+                .tree(tree)
+                .root(inviter)
+                .leaf(invitee)
+                .branchDegree(1)
+                .build();
+    }
+}

--- a/src/main/java/org/example/tree/domain/branch/entity/Branch.java
+++ b/src/main/java/org/example/tree/domain/branch/entity/Branch.java
@@ -1,11 +1,10 @@
 package org.example.tree.domain.branch.entity;
 
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
+import jakarta.persistence.*;
 import lombok.*;
 import org.example.tree.common.BaseDateTimeEntity;
+import org.example.tree.domain.profile.entity.Profile;
+import org.example.tree.domain.tree.entity.Tree;
 
 @Entity
 @Getter
@@ -16,4 +15,17 @@ public class Branch extends BaseDateTimeEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
+
+    private Integer branchDegree;
+
+    @JoinColumn(name = "rootId")
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Profile root;
+    @JoinColumn(name = "leafId")
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Profile leaf;
+
+    @JoinColumn(name = "treeId")
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Tree tree;
 }

--- a/src/main/java/org/example/tree/domain/branch/repository/BranchRepository.java
+++ b/src/main/java/org/example/tree/domain/branch/repository/BranchRepository.java
@@ -17,4 +17,6 @@ public interface BranchRepository extends JpaRepository<Branch, Long> {
     Optional<Branch> findByTreeIdAndRootIdAndLeafId(@Param("treeId") Long treeId,
                                                     @Param("rootId") Long rootId,
                                                     @Param("leafId") Long leafId);
+
+    Optional<Branch> findByTree_IdAndLeaf_Id(Long treeId, Long profileId);
 }

--- a/src/main/java/org/example/tree/domain/branch/repository/BranchRepository.java
+++ b/src/main/java/org/example/tree/domain/branch/repository/BranchRepository.java
@@ -6,6 +6,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
 @Repository
@@ -18,5 +19,6 @@ public interface BranchRepository extends JpaRepository<Branch, Long> {
                                                     @Param("rootId") Long rootId,
                                                     @Param("leafId") Long leafId);
 
-    Optional<Branch> findByTree_IdAndLeaf_Id(Long treeId, Long profileId);
+
+    List<Branch> findAllByTree_Id(Long treeId);
 }

--- a/src/main/java/org/example/tree/domain/branch/repository/BranchRepository.java
+++ b/src/main/java/org/example/tree/domain/branch/repository/BranchRepository.java
@@ -2,8 +2,19 @@ package org.example.tree.domain.branch.repository;
 
 import org.example.tree.domain.branch.entity.Branch;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
 
 @Repository
 public interface BranchRepository extends JpaRepository<Branch, Long> {
+    @Query("SELECT b FROM Branch b " +
+            "WHERE b.tree.id = :treeId " +
+            "AND b.root.id = :rootId " +
+            "AND b.leaf.id = :leafId")
+    Optional<Branch> findByTreeIdAndRootIdAndLeafId(@Param("treeId") Long treeId,
+                                                    @Param("rootId") Long rootId,
+                                                    @Param("leafId") Long leafId);
 }

--- a/src/main/java/org/example/tree/domain/branch/service/BranchCommandService.java
+++ b/src/main/java/org/example/tree/domain/branch/service/BranchCommandService.java
@@ -1,0 +1,16 @@
+package org.example.tree.domain.branch.service;
+
+import lombok.RequiredArgsConstructor;
+import org.example.tree.domain.branch.entity.Branch;
+import org.example.tree.domain.branch.repository.BranchRepository;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class BranchCommandService {
+    private final BranchRepository branchRepository;
+
+    public void createBranch(Branch branch) {
+        branchRepository.save(branch);
+    }
+}

--- a/src/main/java/org/example/tree/domain/branch/service/BranchQueryService.java
+++ b/src/main/java/org/example/tree/domain/branch/service/BranchQueryService.java
@@ -1,0 +1,19 @@
+package org.example.tree.domain.branch.service;
+
+import lombok.RequiredArgsConstructor;
+import org.example.tree.domain.branch.entity.Branch;
+import org.example.tree.domain.branch.repository.BranchRepository;
+import org.example.tree.global.exception.GeneralException;
+import org.example.tree.global.exception.GlobalErrorCode;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class BranchQueryService {
+    private final BranchRepository branchRepository;
+
+    public Branch findBranch(Long treeId, Long rootId, Long leafId) {
+        return branchRepository.findByTreeIdAndRootIdAndLeafId(treeId, rootId, leafId)
+                .orElseThrow(() -> new GeneralException(GlobalErrorCode.BRANCH_NOT_FOUND));
+    }
+}

--- a/src/main/java/org/example/tree/domain/branch/service/BranchQueryService.java
+++ b/src/main/java/org/example/tree/domain/branch/service/BranchQueryService.java
@@ -16,4 +16,9 @@ public class BranchQueryService {
         return branchRepository.findByTreeIdAndRootIdAndLeafId(treeId, rootId, leafId)
                 .orElseThrow(() -> new GeneralException(GlobalErrorCode.BRANCH_NOT_FOUND));
     }
+
+    public Branch findByTreeIdAndLeafId(Long treeId, Long profileId) {
+        return branchRepository.findByTree_IdAndLeaf_Id(treeId, profileId)
+                .orElseThrow(() -> new GeneralException(GlobalErrorCode.BRANCH_NOT_FOUND));
+    }
 }

--- a/src/main/java/org/example/tree/domain/branch/service/BranchQueryService.java
+++ b/src/main/java/org/example/tree/domain/branch/service/BranchQueryService.java
@@ -7,6 +7,8 @@ import org.example.tree.global.exception.GeneralException;
 import org.example.tree.global.exception.GlobalErrorCode;
 import org.springframework.stereotype.Service;
 
+import java.util.List;
+
 @Service
 @RequiredArgsConstructor
 public class BranchQueryService {
@@ -17,8 +19,7 @@ public class BranchQueryService {
                 .orElseThrow(() -> new GeneralException(GlobalErrorCode.BRANCH_NOT_FOUND));
     }
 
-    public Branch findByTreeIdAndLeafId(Long treeId, Long profileId) {
-        return branchRepository.findByTree_IdAndLeaf_Id(treeId, profileId)
-                .orElseThrow(() -> new GeneralException(GlobalErrorCode.BRANCH_NOT_FOUND));
+    public List<Branch> findAllBranchesInTree(Long treeId) {
+        return branchRepository.findAllByTree_Id(treeId);
     }
 }

--- a/src/main/java/org/example/tree/domain/branch/service/BranchService.java
+++ b/src/main/java/org/example/tree/domain/branch/service/BranchService.java
@@ -20,10 +20,7 @@ public class BranchService {
     private final BranchConverter branchConverter;
 
     @Transactional
-    public void createBranch(Long treeId,Long inviterId, Long inviteeId) {
-        Tree tree = treeQueryService.findById(treeId);
-        Profile inviter = profileQueryService.findById(inviterId);
-        Profile invitee = profileQueryService.findById(inviteeId);
+    public void createBranch(Tree tree,Profile inviter, Profile invitee) {
         Branch branch = branchConverter.toBranch(tree, inviter, invitee);
         branchCommandService.createBranch(branch);
     }
@@ -33,4 +30,26 @@ public class BranchService {
         Branch branch = branchQueryService.findBranch(treeId, rootId, leafId);
         return branch.getBranchDegree();
     }
+
+    public int calculateBranchDegree(Long treeId, Long rootId, Long leafId) {
+        int degree = 1;
+        Long currentMemberId = leafId;
+
+        while (true) {
+            // 현재 멤버를 초대한 멤버를 찾습니다.
+            Branch branch = branchQueryService.findByTreeIdAndLeafId(treeId, currentMemberId);
+            Long inviterId = branch.getRoot().getId();
+            // 루트 사용자에 도달했거나, 더 이상 상위 사용자가 없는 경우 루프를 종료합니다.
+            if ((branch == null) || (inviterId.equals(rootId))) {
+                break;
+            }
+
+            // BranchDegree를 증가시키고, 다음 상위 사용자로 이동합니다.
+            degree++;
+            currentMemberId = inviterId;
+        }
+        System.out.println("degree = " + degree);
+        return degree;
+    }
 }
+

--- a/src/main/java/org/example/tree/domain/branch/service/BranchService.java
+++ b/src/main/java/org/example/tree/domain/branch/service/BranchService.java
@@ -1,4 +1,36 @@
 package org.example.tree.domain.branch.service;
 
+import lombok.RequiredArgsConstructor;
+import org.example.tree.domain.branch.converter.BranchConverter;
+import org.example.tree.domain.branch.entity.Branch;
+import org.example.tree.domain.profile.entity.Profile;
+import org.example.tree.domain.profile.service.ProfileQueryService;
+import org.example.tree.domain.tree.entity.Tree;
+import org.example.tree.domain.tree.service.TreeQueryService;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+@RequiredArgsConstructor
 public class BranchService {
+    private final ProfileQueryService profileQueryService;
+    private final TreeQueryService treeQueryService;
+    private final BranchCommandService branchCommandService;
+    private final BranchQueryService branchQueryService;
+    private final BranchConverter branchConverter;
+
+    @Transactional
+    public void createBranch(Long treeId,Long inviterId, Long inviteeId) {
+        Tree tree = treeQueryService.findById(treeId);
+        Profile inviter = profileQueryService.findById(inviterId);
+        Profile invitee = profileQueryService.findById(inviteeId);
+        Branch branch = branchConverter.toBranch(tree, inviter, invitee);
+        branchCommandService.createBranch(branch);
+    }
+
+    @Transactional
+    public Integer getBranchDegree(Long treeId, Long rootId, Long leafId) {
+        Branch branch = branchQueryService.findBranch(treeId, rootId, leafId);
+        return branch.getBranchDegree();
+    }
 }

--- a/src/main/java/org/example/tree/domain/invitation/controller/InvitationController.java
+++ b/src/main/java/org/example/tree/domain/invitation/controller/InvitationController.java
@@ -36,6 +36,13 @@ public class InvitationController {
         return ApiResponse.onSuccess(invitationService.acceptInvitation(request));
     }
 
+    @PostMapping("/trees/members/invitation/reject")
+    public ApiResponse<InvitationResponseDTO.rejectInvitation> rejectInvitation(
+            @RequestBody final InvitationRequestDTO.rejectInvitation request
+    ) {
+        return ApiResponse.onSuccess(invitationService.rejectInvitation(request));
+    }
+
     @GetMapping("/users/invitation")
     public ApiResponse<List<InvitationResponseDTO.getInvitation>> getInvitation(
             @RequestHeader("Authorization") final String header

--- a/src/main/java/org/example/tree/domain/invitation/converter/InvitationConverter.java
+++ b/src/main/java/org/example/tree/domain/invitation/converter/InvitationConverter.java
@@ -32,6 +32,13 @@ public class InvitationConverter {
                 .build();
     }
 
+    public InvitationResponseDTO.rejectInvitation toRejectInvitation (Invitation invitation) {
+        return InvitationResponseDTO.rejectInvitation.builder()
+                .treeId(invitation.getTree().getId())
+                .isAccept(false)
+                .build();
+    }
+
     public InvitationResponseDTO.getAvailableInvitation toGetAvailableInvitation (Member member) {
         return InvitationResponseDTO.getAvailableInvitation.builder()
                 .availableInvitation(member.getInvitationCount())

--- a/src/main/java/org/example/tree/domain/invitation/converter/InvitationConverter.java
+++ b/src/main/java/org/example/tree/domain/invitation/converter/InvitationConverter.java
@@ -3,6 +3,7 @@ package org.example.tree.domain.invitation.converter;
 import org.example.tree.domain.invitation.dto.InvitationResponseDTO;
 import org.example.tree.domain.invitation.entity.Invitation;
 import org.example.tree.domain.member.entity.Member;
+import org.example.tree.domain.profile.entity.Profile;
 import org.example.tree.domain.tree.entity.Tree;
 import org.springframework.stereotype.Component;
 
@@ -10,7 +11,7 @@ import java.util.ArrayList;
 
 @Component
 public class InvitationConverter {
-    public Invitation toInvitation (Member sender, Tree tree, String phone) {
+    public Invitation toInvitation (Profile sender, Tree tree, String phone) {
         return Invitation.builder()
                 .sender(sender)
                 .tree(tree)
@@ -20,7 +21,7 @@ public class InvitationConverter {
 
     public InvitationResponseDTO.sendInvitation toInviteUser (Invitation savedInvitation, Boolean isNewUser) {
         return InvitationResponseDTO.sendInvitation.builder()
-                .availableInvitation(savedInvitation.getSender().getInvitationCount())
+                .availableInvitation(savedInvitation.getSender().getMember().getInvitationCount())
                 .isNewUser(isNewUser)
                 .build();
     }
@@ -50,7 +51,7 @@ public class InvitationConverter {
         return InvitationResponseDTO.getInvitation.builder()
                 .invitationId(invitation.getId())
                 .treeName(invitation.getTree().getName())
-                .senderName(invitation.getSender().getId())
+                .senderName(invitation.getSender().getMemberName())
                 .treeSize(invitation.getTree().getTreeSize())
                 .treeMemberProfileImages(new ArrayList<>())
                 .build();

--- a/src/main/java/org/example/tree/domain/invitation/dto/InvitationRequestDTO.java
+++ b/src/main/java/org/example/tree/domain/invitation/dto/InvitationRequestDTO.java
@@ -26,4 +26,15 @@ public class InvitationRequestDTO {
         private Long invitationId;
         private Boolean isAccept;
     }
+
+    @Getter
+    public static class getInvitation {
+        private Long invitationId;
+    }
+
+    @Getter
+    public static class rejectInvitation {
+        private Long invitationId;
+        private Boolean isAccept;
+    }
 }

--- a/src/main/java/org/example/tree/domain/invitation/dto/InvitationResponseDTO.java
+++ b/src/main/java/org/example/tree/domain/invitation/dto/InvitationResponseDTO.java
@@ -29,6 +29,15 @@ public class InvitationResponseDTO {
     @Getter
     @NoArgsConstructor
     @AllArgsConstructor
+    public static class rejectInvitation {
+        private Long treeId;
+        private Boolean isAccept;
+    }
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
     public static class getInvitation {
         private Long invitationId;
         private String treeName;

--- a/src/main/java/org/example/tree/domain/invitation/entity/Invitation.java
+++ b/src/main/java/org/example/tree/domain/invitation/entity/Invitation.java
@@ -20,6 +20,7 @@ public class Invitation extends BaseDateTimeEntity {
 
     private String phone;
 
+    @Setter
     private InvitationStatus status;
 
     private LocalDateTime expiredAt; //초대장 만료일자

--- a/src/main/java/org/example/tree/domain/invitation/entity/Invitation.java
+++ b/src/main/java/org/example/tree/domain/invitation/entity/Invitation.java
@@ -4,6 +4,7 @@ import jakarta.persistence.*;
 import lombok.*;
 import org.example.tree.common.BaseDateTimeEntity;
 import org.example.tree.domain.member.entity.Member;
+import org.example.tree.domain.profile.entity.Profile;
 import org.example.tree.domain.tree.entity.Tree;
 
 import java.time.LocalDateTime;
@@ -27,7 +28,7 @@ public class Invitation extends BaseDateTimeEntity {
 
     @JoinColumn(name = "senderId")
     @ManyToOne(fetch = FetchType.LAZY)
-    private Member sender;
+    private Profile sender;
     @JoinColumn(name = "treeId")
     @ManyToOne(fetch = FetchType.LAZY)
     private Tree tree;

--- a/src/main/java/org/example/tree/domain/invitation/repository/InvitationRepository.java
+++ b/src/main/java/org/example/tree/domain/invitation/repository/InvitationRepository.java
@@ -1,12 +1,16 @@
 package org.example.tree.domain.invitation.repository;
 
 import org.example.tree.domain.invitation.entity.Invitation;
+import org.example.tree.domain.tree.entity.Tree;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface InvitationRepository extends JpaRepository<Invitation, Long> {
     List<Invitation> findAllByPhone(String phone);
+
+    Optional<Invitation> findByPhoneAndTree(String phone, Tree tree);
 }

--- a/src/main/java/org/example/tree/domain/invitation/service/InvitationCommandService.java
+++ b/src/main/java/org/example/tree/domain/invitation/service/InvitationCommandService.java
@@ -2,6 +2,7 @@ package org.example.tree.domain.invitation.service;
 
 import lombok.RequiredArgsConstructor;
 import org.example.tree.domain.invitation.entity.Invitation;
+import org.example.tree.domain.invitation.entity.InvitationStatus;
 import org.example.tree.domain.invitation.repository.InvitationRepository;
 import org.example.tree.domain.member.entity.Member;
 import org.example.tree.domain.tree.entity.Tree;
@@ -16,7 +17,12 @@ public class InvitationCommandService {
         return invitationRepository.save(invitation);
     }
 
-    public void deleteInvitation(Invitation invitation) {
+    public void acceptInvitation(Invitation invitation) {
+        invitation.setStatus(InvitationStatus.ACCEPTED);
+    }
+
+    public void rejectInvitation(Invitation invitation) {
+        invitation.setStatus(InvitationStatus.REJECTED);
         invitationRepository.delete(invitation);
     }
 }

--- a/src/main/java/org/example/tree/domain/invitation/service/InvitationQueryService.java
+++ b/src/main/java/org/example/tree/domain/invitation/service/InvitationQueryService.java
@@ -3,6 +3,8 @@ package org.example.tree.domain.invitation.service;
 import lombok.RequiredArgsConstructor;
 import org.example.tree.domain.invitation.entity.Invitation;
 import org.example.tree.domain.invitation.repository.InvitationRepository;
+import org.example.tree.domain.member.entity.Member;
+import org.example.tree.domain.tree.entity.Tree;
 import org.example.tree.global.exception.GeneralException;
 import org.example.tree.global.exception.GlobalErrorCode;
 import org.springframework.stereotype.Service;
@@ -20,5 +22,10 @@ public class InvitationQueryService {
 
     public List<Invitation> findAllByPhone(String phone) {
         return invitationRepository.findAllByPhone(phone);
+    }
+
+    public Invitation findReceivedInvitation(Member member, Tree tree) {
+        return invitationRepository.findByPhoneAndTree(member.getPhone(), tree)
+                .orElseThrow(() -> new GeneralException(GlobalErrorCode.INVITATION_NOT_FOUND));
     }
 }

--- a/src/main/java/org/example/tree/domain/invitation/service/InvitationService.java
+++ b/src/main/java/org/example/tree/domain/invitation/service/InvitationService.java
@@ -51,7 +51,7 @@ public class InvitationService {
     }
 
     @Transactional
-    public  InvitationResponseDTO.acceptInvitation acceptInvitation(InvitationRequestDTO.acceptInvitation request) {
+    public InvitationResponseDTO.acceptInvitation acceptInvitation(InvitationRequestDTO.acceptInvitation request) {
         Invitation invitation = invitationQueryService.findById(request.getInvitationId());
         invitationCommandService.acceptInvitation(invitation);
         return invitationConverter.toAcceptInvitation(invitation);

--- a/src/main/java/org/example/tree/domain/invitation/service/InvitationService.java
+++ b/src/main/java/org/example/tree/domain/invitation/service/InvitationService.java
@@ -53,8 +53,15 @@ public class InvitationService {
     @Transactional
     public  InvitationResponseDTO.acceptInvitation acceptInvitation(InvitationRequestDTO.acceptInvitation request) {
         Invitation invitation = invitationQueryService.findById(request.getInvitationId());
-        invitationCommandService.deleteInvitation(invitation);
+        invitationCommandService.acceptInvitation(invitation);
         return invitationConverter.toAcceptInvitation(invitation);
+    }
+
+    @Transactional
+    public InvitationResponseDTO.rejectInvitation rejectInvitation(InvitationRequestDTO.rejectInvitation request) {
+        Invitation invitation = invitationQueryService.findById(request.getInvitationId());
+        invitationCommandService.rejectInvitation(invitation);
+        return invitationConverter.toRejectInvitation(invitation);
     }
 
     @Transactional

--- a/src/main/java/org/example/tree/domain/invitation/service/InvitationService.java
+++ b/src/main/java/org/example/tree/domain/invitation/service/InvitationService.java
@@ -2,12 +2,15 @@ package org.example.tree.domain.invitation.service;
 
 
 import lombok.RequiredArgsConstructor;
+import org.example.tree.domain.branch.service.BranchService;
 import org.example.tree.domain.invitation.converter.InvitationConverter;
 import org.example.tree.domain.invitation.dto.InvitationRequestDTO;
 import org.example.tree.domain.invitation.dto.InvitationResponseDTO;
 import org.example.tree.domain.invitation.entity.Invitation;
 import org.example.tree.domain.member.entity.Member;
 import org.example.tree.domain.member.service.MemberQueryService;
+import org.example.tree.domain.profile.entity.Profile;
+import org.example.tree.domain.profile.service.ProfileQueryService;
 import org.example.tree.domain.tree.entity.Tree;
 import org.example.tree.domain.tree.service.TreeQueryService;
 import org.springframework.stereotype.Component;
@@ -24,14 +27,16 @@ public class InvitationService {
     private final InvitationQueryService invitationQueryService;
     private final MemberQueryService memberQueryService;
     private final TreeQueryService treeQueryService;
+    private final ProfileQueryService profileQueryService;
+    private final BranchService branchService;
     private final InvitationConverter invitationConverter;
 
     @Transactional
     public InvitationResponseDTO.sendInvitation inviteUser(InvitationRequestDTO.sendInvitation request) {
-        Member sender = memberQueryService.findById(request.getSenderId());
-        sender.decreaseInvitationCount();
-
+        Member member = memberQueryService.findById(request.getSenderId());
+        member.decreaseInvitationCount();
         Tree tree = treeQueryService.findById(request.getTreeId());
+        Profile sender = profileQueryService.getTreeProfile(member, tree);
         Invitation invitation = invitationConverter.toInvitation(sender, tree, request.getPhoneNumber());
         Optional<Member> optionalMember = memberQueryService.findByPhoneNumber(request.getPhoneNumber());
         Boolean isNewUser = !optionalMember.isPresent();
@@ -41,10 +46,10 @@ public class InvitationService {
 
     @Transactional
     public void inviteMember(InvitationRequestDTO.inviteMember request) {
-        Member sender = memberQueryService.findById(request.getSenderId());
-        sender.decreaseInvitationCount();
-
+        Member member = memberQueryService.findById(request.getSenderId());
+        member.decreaseInvitationCount();
         Tree tree = treeQueryService.findById(request.getTreeId());
+        Profile sender = profileQueryService.getTreeProfile(member, tree);
         Member targetMember = memberQueryService.findById(request.getTargetUserId());
         Invitation invitation = invitationConverter.toInvitation(sender, tree, targetMember.getPhone());
         invitationCommandService.createInvitation(invitation);

--- a/src/main/java/org/example/tree/domain/member/controller/MemberController.java
+++ b/src/main/java/org/example/tree/domain/member/controller/MemberController.java
@@ -12,11 +12,6 @@ import org.springframework.web.bind.annotation.*;
 @RequestMapping("/users")
 public class MemberController {
     private final MemberService memberService;
-
-    @GetMapping("/test")
-    public ApiResponse test() {
-        return ApiResponse.onSuccess("test");
-    }
     @PostMapping("/checkId")
     public ApiResponse<MemberResponseDTO.checkId> checkId(
             @RequestBody final MemberRequestDTO.checkId request

--- a/src/main/java/org/example/tree/domain/post/controller/PostController.java
+++ b/src/main/java/org/example/tree/domain/post/controller/PostController.java
@@ -46,6 +46,16 @@ public class PostController {
         return ApiResponse.onSuccess(postService.getPost(treeId, postId, token));
     }
 
+    @GetMapping("/trees/{treeId}/feed/posts")
+    public ApiResponse<List<PostResponseDTO.getPost>> getPosts(
+            @PathVariable final Long treeId,
+            @RequestParam(name = "member") final Long profileId,
+            @RequestHeader("Authorization") final String header
+    ) {
+        String token = header.replace("Bearer ", "");
+        return ApiResponse.onSuccess(postService.getTreePosts(treeId, profileId, token));
+    }
+
     @PatchMapping("/trees/{treeId}/feed/posts/{postId}")
     public ApiResponse updatePost(
             @PathVariable final Long treeId,

--- a/src/main/java/org/example/tree/domain/post/repository/PostRepository.java
+++ b/src/main/java/org/example/tree/domain/post/repository/PostRepository.java
@@ -1,6 +1,7 @@
 package org.example.tree.domain.post.repository;
 
 import org.example.tree.domain.post.entity.Post;
+import org.example.tree.domain.profile.entity.Profile;
 import org.example.tree.domain.tree.entity.Tree;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
@@ -10,4 +11,5 @@ import java.util.List;
 @Repository
 public interface PostRepository extends JpaRepository<Post, Long> {
     List<Post> findAllByTree(Tree tree);
+    List<Post> findAllByProfile_Id(Long profileId);
 }

--- a/src/main/java/org/example/tree/domain/post/service/PostQueryService.java
+++ b/src/main/java/org/example/tree/domain/post/service/PostQueryService.java
@@ -3,6 +3,7 @@ package org.example.tree.domain.post.service;
 import lombok.RequiredArgsConstructor;
 import org.example.tree.domain.post.entity.Post;
 import org.example.tree.domain.post.repository.PostRepository;
+import org.example.tree.domain.profile.entity.Profile;
 import org.example.tree.domain.tree.entity.Tree;
 import org.example.tree.global.exception.GeneralException;
 import org.example.tree.global.exception.GlobalErrorCode;
@@ -21,5 +22,10 @@ public class PostQueryService {
     }
     public List<Post> getPosts(Tree tree) {
         return postRepository.findAllByTree(tree);
+    }
+
+
+    public List<Post> findByProfileId(Long profileId) {
+        return postRepository.findAllByProfile_Id(profileId);
     }
 }

--- a/src/main/java/org/example/tree/domain/post/service/PostService.java
+++ b/src/main/java/org/example/tree/domain/post/service/PostService.java
@@ -73,6 +73,17 @@ public class PostService {
     }
 
     @Transactional
+    public List<PostResponseDTO.getPost> getTreePosts(Long treeId, Long profileId, String token) {
+        List<Post> posts = postQueryService.findByProfileId(profileId);
+        return posts.stream()
+                .map(post -> {
+                    List<ReactionResponseDTO.getReaction> reactions = reactionService.getPostReactions(treeId, post.getId(), token);
+                    return postConverter.toGetPost(post, reactions);
+                })
+                .collect(Collectors.toList());
+    }
+
+    @Transactional
     public void updatePost(Long treeId, Long postId, PostRequestDTO.updatePost request, String token) {
         Profile profile = profileService.getTreeProfile(token, treeId);
         Post post = postQueryService.findById(postId);

--- a/src/main/java/org/example/tree/domain/profile/controller/ProfileController.java
+++ b/src/main/java/org/example/tree/domain/profile/controller/ProfileController.java
@@ -20,4 +20,13 @@ public class ProfileController {
             ) throws Exception {
         return ApiResponse.onSuccess(profileService.createProfile(request, profileImage));
     }
+
+    @GetMapping("/trees/{treeId}/members/{memberId}") //프로필 조회
+    public ApiResponse getProfileDetails(
+            @PathVariable Long treeId,
+            @PathVariable String memberId) {
+        return ApiResponse.onSuccess(profileService.getProfileDetails(memberId));
+    }
+
+
 }

--- a/src/main/java/org/example/tree/domain/profile/controller/ProfileController.java
+++ b/src/main/java/org/example/tree/domain/profile/controller/ProfileController.java
@@ -13,6 +13,15 @@ import org.springframework.web.multipart.MultipartFile;
 @RequiredArgsConstructor
 public class ProfileController {
     private final ProfileService profileService;
+
+    @PostMapping(value = "/trees/owner/register", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ApiResponse registerTreeOwner(
+            @RequestPart ProfileRequestDTO.ownerProfile request,
+            @RequestPart("profileImage") final MultipartFile profileImage
+    ) throws Exception {
+        return ApiResponse.onSuccess(profileService.ownerProfile(request, profileImage));
+    }
+
     @PostMapping(value = "/trees/members/register", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ApiResponse registerTreeMember(
             @RequestPart ProfileRequestDTO.createProfile request,
@@ -23,9 +32,11 @@ public class ProfileController {
 
     @GetMapping("/trees/{treeId}/members/{profileId}") //프로필 조회
     public ApiResponse getProfileDetails(
+            @RequestHeader("Authorization") final String header,
             @PathVariable Long treeId,
             @PathVariable Long profileId) {
-        return ApiResponse.onSuccess(profileService.getProfileDetails(profileId));
+        String token = header.replace("Bearer ", "");
+        return ApiResponse.onSuccess(profileService.getProfileDetails(token, profileId));
     }
 
     @GetMapping("/trees/{treeId}/myProfile") //내 프로필 조회

--- a/src/main/java/org/example/tree/domain/profile/controller/ProfileController.java
+++ b/src/main/java/org/example/tree/domain/profile/controller/ProfileController.java
@@ -21,12 +21,19 @@ public class ProfileController {
         return ApiResponse.onSuccess(profileService.createProfile(request, profileImage));
     }
 
-    @GetMapping("/trees/{treeId}/members/{memberId}") //프로필 조회
+    @GetMapping("/trees/{treeId}/members/{profileId}") //프로필 조회
     public ApiResponse getProfileDetails(
             @PathVariable Long treeId,
-            @PathVariable String memberId) {
-        return ApiResponse.onSuccess(profileService.getProfileDetails(memberId));
+            @PathVariable Long profileId) {
+        return ApiResponse.onSuccess(profileService.getProfileDetails(profileId));
     }
 
-
+    @GetMapping("/trees/{treeId}/myProfile") //내 프로필 조회
+    public ApiResponse getMyProfile(
+            @RequestHeader("Authorization") final String header,
+            @PathVariable Long treeId
+    ) {
+        String token = header.replace("Bearer ", "");
+        return ApiResponse.onSuccess(profileService.getMyProfile(token, treeId));
+    }
 }

--- a/src/main/java/org/example/tree/domain/profile/converter/ProfileConverter.java
+++ b/src/main/java/org/example/tree/domain/profile/converter/ProfileConverter.java
@@ -7,6 +7,8 @@ import org.example.tree.domain.tree.entity.Tree;
 import org.springframework.stereotype.Component;
 import org.springframework.web.multipart.MultipartFile;
 
+import java.util.List;
+
 @Component
 public class ProfileConverter {
     public Profile toProfile (Tree tree, Member member, String memberName, String bio, String profileImageUrl) {
@@ -24,6 +26,17 @@ public class ProfileConverter {
                 .profileId(profile.getId())
                 .treeId(profile.getTree().getId())
                 .memberName(profile.getMemberName())
+                .profileImageUrl(profile.getProfileImageUrl())
+                .build();
+    }
+
+    public ProfileResponseDTO.getProfileDetails toGetProfileDetails(Profile profile, List<Long> treeIds) {
+        return ProfileResponseDTO.getProfileDetails.builder()
+                .profileId(profile.getId())
+                .treeIds(treeIds)
+                .memberId(profile.getMember().getId())
+                .memberName(profile.getMemberName())
+                .bio(profile.getBio())
                 .profileImageUrl(profile.getProfileImageUrl())
                 .build();
     }

--- a/src/main/java/org/example/tree/domain/profile/converter/ProfileConverter.java
+++ b/src/main/java/org/example/tree/domain/profile/converter/ProfileConverter.java
@@ -30,7 +30,7 @@ public class ProfileConverter {
                 .build();
     }
 
-    public ProfileResponseDTO.getProfileDetails toGetProfileDetails(Profile profile, List<Long> treeIds) {
+    public ProfileResponseDTO.getProfileDetails toGetProfileDetails(Profile profile, List<Long> treeIds, int branchDegree) {
         return ProfileResponseDTO.getProfileDetails.builder()
                 .profileId(profile.getId())
                 .treeIds(treeIds)
@@ -38,6 +38,7 @@ public class ProfileConverter {
                 .memberName(profile.getMemberName())
                 .bio(profile.getBio())
                 .profileImageUrl(profile.getProfileImageUrl())
+                .branchDegree(branchDegree)
                 .build();
     }
 

--- a/src/main/java/org/example/tree/domain/profile/dto/ProfileRequestDTO.java
+++ b/src/main/java/org/example/tree/domain/profile/dto/ProfileRequestDTO.java
@@ -16,4 +16,14 @@ public class ProfileRequestDTO {
         private String bio;
 
     }
+
+    @Getter
+    public static class ownerProfile {
+        private Long treeId;
+        private String userId;
+        private String memberName;
+        private MultipartFile profileImage;
+        private String bio;
+
+    }
 }

--- a/src/main/java/org/example/tree/domain/profile/dto/ProfileResponseDTO.java
+++ b/src/main/java/org/example/tree/domain/profile/dto/ProfileResponseDTO.java
@@ -29,6 +29,6 @@ public class ProfileResponseDTO {
         private String memberName;
         private String bio;
         private String profileImageUrl;
-        private Integer branch;
+        private Integer branchDegree;
     }
 }

--- a/src/main/java/org/example/tree/domain/profile/dto/ProfileResponseDTO.java
+++ b/src/main/java/org/example/tree/domain/profile/dto/ProfileResponseDTO.java
@@ -29,5 +29,6 @@ public class ProfileResponseDTO {
         private String memberName;
         private String bio;
         private String profileImageUrl;
+        private Integer branch;
     }
 }

--- a/src/main/java/org/example/tree/domain/profile/dto/ProfileResponseDTO.java
+++ b/src/main/java/org/example/tree/domain/profile/dto/ProfileResponseDTO.java
@@ -2,6 +2,8 @@ package org.example.tree.domain.profile.dto;
 
 import lombok.*;
 
+import java.util.List;
+
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class ProfileResponseDTO {
 
@@ -13,6 +15,19 @@ public class ProfileResponseDTO {
         private Long profileId;
         private Long treeId;
         private String memberName;
+        private String profileImageUrl;
+    }
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class getProfileDetails {
+        private Long profileId;
+        private List<Long> treeIds;
+        private String memberId;
+        private String memberName;
+        private String bio;
         private String profileImageUrl;
     }
 }

--- a/src/main/java/org/example/tree/domain/profile/repository/ProfileRepository.java
+++ b/src/main/java/org/example/tree/domain/profile/repository/ProfileRepository.java
@@ -12,4 +12,8 @@ import java.util.Optional;
 public interface ProfileRepository extends JpaRepository<Profile, Long> {
 
     Optional<Profile> findByMemberAndTree(Member member, Tree tree);
+
+    Optional<Object> findByMember_Id(String memberId);
+
+    List<Profile> findAllByMember_Id(String memberId);
 }

--- a/src/main/java/org/example/tree/domain/profile/repository/ProfileRepository.java
+++ b/src/main/java/org/example/tree/domain/profile/repository/ProfileRepository.java
@@ -13,7 +13,7 @@ public interface ProfileRepository extends JpaRepository<Profile, Long> {
 
     Optional<Profile> findByMemberAndTree(Member member, Tree tree);
 
-    Optional<Object> findByMember_Id(String memberId);
 
     List<Profile> findAllByMember_Id(String memberId);
+
 }

--- a/src/main/java/org/example/tree/domain/profile/service/ProfileQueryService.java
+++ b/src/main/java/org/example/tree/domain/profile/service/ProfileQueryService.java
@@ -20,4 +20,16 @@ public class ProfileQueryService {
         return profileRepository.findByMemberAndTree(member, tree)
                 .orElseThrow(() -> new GeneralException(GlobalErrorCode.PROFILE_NOT_FOUND));
     }
+
+    public Profile findByMemberId(String memberId) {
+        return (Profile) profileRepository.findByMember_Id(memberId)
+                .orElseThrow(() -> new GeneralException(GlobalErrorCode.PROFILE_NOT_FOUND));
+    }
+
+    public List<Long> findJoinedTree(String memberId) {
+        List<Profile> profiles = profileRepository.findAllByMember_Id(memberId);
+        return profiles.stream()
+                .map(profile -> profile.getTree().getId())
+                .toList();
+    }
 }

--- a/src/main/java/org/example/tree/domain/profile/service/ProfileQueryService.java
+++ b/src/main/java/org/example/tree/domain/profile/service/ProfileQueryService.java
@@ -21,15 +21,16 @@ public class ProfileQueryService {
                 .orElseThrow(() -> new GeneralException(GlobalErrorCode.PROFILE_NOT_FOUND));
     }
 
-    public Profile findByMemberId(String memberId) {
-        return (Profile) profileRepository.findByMember_Id(memberId)
+    public Profile findById(Long profileId) {
+        return profileRepository.findById(profileId)
                 .orElseThrow(() -> new GeneralException(GlobalErrorCode.PROFILE_NOT_FOUND));
     }
 
-    public List<Long> findJoinedTree(String memberId) {
-        List<Profile> profiles = profileRepository.findAllByMember_Id(memberId);
-        return profiles.stream()
-                .map(profile -> profile.getTree().getId())
+    public List<Long> findJoinedTree(Profile profile) {
+        String memberId = profile.getMember().getId();
+        List<Profile> foundProfiles = profileRepository.findAllByMember_Id(memberId);
+        return foundProfiles.stream()
+                .map(foundProfile -> foundProfile.getTree().getId())
                 .toList();
     }
 }

--- a/src/main/java/org/example/tree/domain/profile/service/ProfileService.java
+++ b/src/main/java/org/example/tree/domain/profile/service/ProfileService.java
@@ -4,6 +4,7 @@ import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.example.tree.domain.member.entity.Member;
 import org.example.tree.domain.member.service.MemberQueryService;
+import org.example.tree.domain.post.service.PostService;
 import org.example.tree.domain.profile.converter.ProfileConverter;
 import org.example.tree.domain.profile.dto.ProfileRequestDTO;
 import org.example.tree.domain.profile.dto.ProfileResponseDTO;
@@ -47,9 +48,18 @@ public class ProfileService {
     }
 
     @Transactional
-    public ProfileResponseDTO.getProfileDetails getProfileDetails(String memberId) {
-        Profile profile = profileQueryService.findByMemberId(memberId);
-        List<Long> treeIds = profileQueryService.findJoinedTree(memberId);
+    public ProfileResponseDTO.getProfileDetails getProfileDetails(Long profileId) {
+        Profile profile = profileQueryService.findById(profileId);
+        List<Long> treeIds = profileQueryService.findJoinedTree(profile);
+        return profileConverter.toGetProfileDetails(profile, treeIds);
+    }
+
+    @Transactional
+    public ProfileResponseDTO.getProfileDetails getMyProfile(String token, Long treeId) {
+        Member member = memberQueryService.findByToken(token);
+        Tree tree = treeQueryService.findById(treeId);
+        Profile profile = profileQueryService.getTreeProfile(member,tree);
+        List<Long> treeIds = profileQueryService.findJoinedTree(profile);
         return profileConverter.toGetProfileDetails(profile, treeIds);
     }
 }

--- a/src/main/java/org/example/tree/domain/profile/service/ProfileService.java
+++ b/src/main/java/org/example/tree/domain/profile/service/ProfileService.java
@@ -62,4 +62,5 @@ public class ProfileService {
         List<Long> treeIds = profileQueryService.findJoinedTree(profile);
         return profileConverter.toGetProfileDetails(profile, treeIds);
     }
+
 }

--- a/src/main/java/org/example/tree/domain/profile/service/ProfileService.java
+++ b/src/main/java/org/example/tree/domain/profile/service/ProfileService.java
@@ -45,4 +45,11 @@ public class ProfileService {
         Tree tree = treeQueryService.findById(treeId);
         return profileQueryService.getTreeProfile(member,tree);
     }
+
+    @Transactional
+    public ProfileResponseDTO.getProfileDetails getProfileDetails(String memberId) {
+        Profile profile = profileQueryService.findByMemberId(memberId);
+        List<Long> treeIds = profileQueryService.findJoinedTree(memberId);
+        return profileConverter.toGetProfileDetails(profile, treeIds);
+    }
 }

--- a/src/main/java/org/example/tree/domain/profile/service/ProfileService.java
+++ b/src/main/java/org/example/tree/domain/profile/service/ProfileService.java
@@ -16,6 +16,8 @@ import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
 
+import static org.example.tree.global.consts.TreeStatic.DEFAULT_PROFILE_IMAGE;
+
 @Component
 @RequiredArgsConstructor
 public class ProfileService {
@@ -30,7 +32,7 @@ public class ProfileService {
     public ProfileResponseDTO.createProfile createProfile(ProfileRequestDTO.createProfile request, MultipartFile profileImage) throws Exception {
         Tree tree = treeQueryService.findById(request.getTreeId());
         Member member = memberQueryService.findById(request.getUserId());
-        String profileImageUrl = !profileImage.isEmpty() ? s3UploadService.uploadImage(profileImage) : "";
+        String profileImageUrl = !profileImage.isEmpty() ? s3UploadService.uploadImage(profileImage) : DEFAULT_PROFILE_IMAGE;
         Profile newProfile = profileConverter.toProfile(tree, member, request.getMemberName(), request.getBio(), profileImageUrl);
         profileCommandService.createProfile(newProfile);
         tree.increaseTreeSize();

--- a/src/main/java/org/example/tree/global/consts/TreeStatic.java
+++ b/src/main/java/org/example/tree/global/consts/TreeStatic.java
@@ -1,0 +1,5 @@
+package org.example.tree.global.consts;
+
+public class TreeStatic {
+public static final String DEFAULT_PROFILE_IMAGE = "https://elasticbeanstalk-ap-northeast-2-851725177732.s3.ap-northeast-2.amazonaws.com/images/TreeHouse_default_profile.jpg";
+}

--- a/src/main/java/org/example/tree/global/exception/GlobalErrorCode.java
+++ b/src/main/java/org/example/tree/global/exception/GlobalErrorCode.java
@@ -47,7 +47,10 @@ public enum GlobalErrorCode {
     //Reply
     //404 Not Found - 찾을 수 없음
     REPLY_NOT_FOUND(NOT_FOUND, "존재하지 않는 답글입니다."),
-    ;
+
+    //Branch
+    //404 Not Found - 찾을 수 없음
+    BRANCH_NOT_FOUND(NOT_FOUND, "브랜치 정보를 찾을 수 없습니다.");
 
 
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -48,7 +48,7 @@ spring:
         format_sql: true
         use_sql_comments: true
         hbm2ddl:
-          auto: create-drop
+          auto: update
         default_batch_fetch_size: 1000
 jwt:
   header: Authorization

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -48,7 +48,7 @@ spring:
         format_sql: true
         use_sql_comments: true
         hbm2ddl:
-          auto: update
+          auto: create-drop
         default_batch_fetch_size: 1000
 jwt:
   header: Authorization


### PR DESCRIPTION
# 🚀 개요
<!-- 이 PR을 간략하게 설명해주세요 -->
트리 내에서 프로필 이미지를 선택하지 않은 경우, 기본 프로필 이미지가 저장되도록 설정하였습니다
같은 트리 내 다른 멤버의 프로필 조회 기능을 추가했습니다
'브랜치' 지수를 계산하는 로직을 BFS 알고리즘을 이용해 구현하였습니다

## 🔍 변경사항
<!-- 이 PR로 인해 바뀌게 되는 것들을 목록으로 적어주세요. -->
- **POST** /trees/members/register: 프로필 이미지를 선택하지 않은 경우, 기본 프로필 이미지가 저장되도록 설정
- **POST** /trees/members/register: 트리 가입을 완료한 경우, 자신을 트리에 초대한 사람과의 Branch가 자동 저장되도록 설정
- **POST** /trees/owner/register: 브랜치 지수 계산을 위해 트리를 생성한 유저(설립자)를 위한 별도의 API를 생성
- **POST** /trees/members/invitation/reject: 초대 거절 API 생성
- **GET** /trees/{treeId}/feed/posts: 특정 트리의 멤버가 작성한 게시글 목록 조회 API 생성


## ⏳ 작업 내용
- [x] `BranchService` 클래스에 브랜치 계산을 위한 `calculateBranchDegree`, `findShortestDistance` 메서드 구현
- [x] **POST** /trees/members/register api 서비스 로직 수정
- [x]  **POST** /trees/owner/register 구현
- [x] **POST** /trees/members/invitation/reject: 초대 거절 API 구현
- [x] **GET** /trees/{treeId}/feed/posts: 특정 트리의 멤버가 작성한 게시글 목록 조회 API 구현
- [x] 프로필 조회 시 해당 멤버가 현재 가입된 트리의 treeId 출력 기능 추가

### 📝 논의사항
<!-- 이 PR에 대한 논의하고 싶은 사항이나, 더 해야할 작업, 리뷰어에게 특별히 확인 요청하고 싶은 부분 등을 적어주세요. -->

