### PR TITLE
[FIX]/#44-MemberRole 저장 방식 수정

### DIFF
--- a/src/main/java/org/example/tree/domain/member/converter/MemberConverter.java
+++ b/src/main/java/org/example/tree/domain/member/converter/MemberConverter.java
@@ -12,7 +12,7 @@ public class MemberConverter {
         return Member.builder()
                 .id(id)
                 .phone(phone)
-                .role(MemberRole.valueOf("USER"))
+                .role(MemberRole.USER)
                 .build();
     }
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -48,7 +48,7 @@ spring:
         format_sql: true
         use_sql_comments: true
         hbm2ddl:
-          auto: create-drop
+          auto: update
         default_batch_fetch_size: 1000
 jwt:
   header: Authorization


### PR DESCRIPTION
# 🚀 개요
<!-- 이 PR을 간략하게 설명해주세요 -->
회원가입 시 MemberRole을 저장하는 프로세스 수정

## 🔍 변경사항
<!-- 이 PR로 인해 바뀌게 되는 것들을 목록으로 적어주세요. -->
- MemberRole을 저장할 때 .valueOf 대신 바로 MemberRole.USER로 저장하는 방식으로 수정

## ⏳ 작업 내용
- [x] `MemberConverter`의 `toMember` 메서드 수정

### 📝 논의사항
<!-- 이 PR에 대한 논의하고 싶은 사항이나, 더 해야할 작업, 리뷰어에게 특별히 확인 요청하고 싶은 부분 등을 적어주세요. -->

