### PR TITLE
Feature/49 - 피드 관련 동작 시, 반환값 양식 수정

### DIFF
--- a/src/main/java/org/example/tree/domain/post/controller/PostController.java
+++ b/src/main/java/org/example/tree/domain/post/controller/PostController.java
@@ -23,7 +23,7 @@ public class PostController {
     public ApiResponse<PostResponseDTO.createPost> createPost(
             @PathVariable final Long treeId,
             @RequestHeader("Authorization") final String header,
-            @RequestBody final PostRequestDTO.createPost request
+            @RequestPart final PostRequestDTO.createPost request
     ) throws Exception {
         String token = header.replace("Bearer ", "");
         return ApiResponse.onSuccess(postService.createPost(treeId, request, token));

--- a/src/main/java/org/example/tree/domain/post/converter/PostConverter.java
+++ b/src/main/java/org/example/tree/domain/post/converter/PostConverter.java
@@ -39,20 +39,21 @@ public class PostConverter {
         return PostResponseDTO.createPost.builder()
                 .postId(savedPost.getId())
                 .postImageUrls(imageUrls)
-                .writerId(savedPost.getProfile().getMember().getId())
+                .authorId(savedPost.getProfile().getMember().getId())
                 .treeId(savedPost.getTree().getId())
                 .build();
     }
 
-    public PostResponseDTO.getFeed toGetFeed(Post post, List<ReactionResponseDTO.getReaction> reactions) {
+    public PostResponseDTO.getFeed toGetFeed(Post post, int branchDegree, List<ReactionResponseDTO.getReaction> reactions) {
         List<String> imageUrls = post.getPostImages().stream()
                 .map(PostImage::getImageUrl)
                 .collect(Collectors.toList());
         return PostResponseDTO.getFeed.builder()
                 .postId(post.getId())
-                .postAuthorId(post.getProfile().getId())
+                .authorId(post.getProfile().getId())
                 .profileImageUrl(post.getProfile().getProfileImageUrl())
                 .memberName(post.getProfile().getMemberName())
+                .branchDegree(branchDegree)
                 .content(post.getContent())
                 .postImageUrls(imageUrls)
                 .createdAt(post.getCreatedAt())
@@ -61,7 +62,7 @@ public class PostConverter {
                 .build();
     }
 
-    public PostResponseDTO.getPost toGetPost(Post post, List<ReactionResponseDTO.getReaction> reactions) {
+    public PostResponseDTO.getPost toGetPost(Post post, int branchDegree, List<ReactionResponseDTO.getReaction> reactions) {
         // PostImage 객체 리스트에서 이미지 URL 추출
         List<String> imageUrls = post.getPostImages().stream()
                 .map(PostImage::getImageUrl)
@@ -69,8 +70,10 @@ public class PostConverter {
 
         return PostResponseDTO.getPost.builder()
                 .postId(post.getId())
+                .authorId(post.getProfile().getId())
                 .profileImageUrl(post.getProfile().getProfileImageUrl())
                 .memberName(post.getProfile().getMemberName())
+                .branchDegree(branchDegree)
                 .content(post.getContent())
                 .postImageUrls(imageUrls)
                 .reactions(reactions)

--- a/src/main/java/org/example/tree/domain/post/dto/PostResponseDTO.java
+++ b/src/main/java/org/example/tree/domain/post/dto/PostResponseDTO.java
@@ -17,7 +17,7 @@ public class PostResponseDTO {
     public static class createPost {
         private Long postId;
         private List<String> postImageUrls;
-        private String writerId;
+        private String authorId;
         private Long treeId;
     }
 
@@ -28,9 +28,10 @@ public class PostResponseDTO {
     public static class getFeed {
 
         private Long postId;
-        private Long postAuthorId;
+        private Long authorId;
         private String profileImageUrl;
         private String memberName;
+        private int branchDegree;
         private String content;
         private List<String> postImageUrls;
         private LocalDateTime createdAt;
@@ -45,8 +46,10 @@ public class PostResponseDTO {
     @AllArgsConstructor
     public static class getPost {
         private Long postId;
+        private Long authorId;
         private String profileImageUrl;
         private String memberName;
+        private int branchDegree;
         private String content;
         private List<String> postImageUrls;
         private List<ReactionResponseDTO.getReaction> reactions;

--- a/src/main/java/org/example/tree/domain/reaction/controller/ReactionController.java
+++ b/src/main/java/org/example/tree/domain/reaction/controller/ReactionController.java
@@ -3,6 +3,7 @@ package org.example.tree.domain.reaction.controller;
 import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import org.example.tree.domain.reaction.dto.ReactionRequestDTO;
+import org.example.tree.domain.reaction.dto.ReactionResponseDTO;
 import org.example.tree.domain.reaction.service.ReactionService;
 import org.example.tree.global.common.ApiResponse;
 import org.springframework.web.bind.annotation.*;
@@ -15,41 +16,38 @@ public class ReactionController {
 
     @PostMapping("/trees/{treeId}/feed/posts/{postId}/reaction")
     @Operation(summary = "게시글 리액션", description = "게시글에 리액션을 추가합니다.")
-    public ApiResponse createPostReaction(
+    public ApiResponse<ReactionResponseDTO.addReaction> createPostReaction(
             @PathVariable Long treeId,
             @PathVariable Long postId,
             @RequestHeader("Authorization") String header,
             @RequestBody ReactionRequestDTO.createReaction request
             ) {
         String token = header.replace("Bearer ", "");
-        reactionService.reactToPost(treeId, postId, request, token);
-        return ApiResponse.onSuccess("");
+        return ApiResponse.onSuccess(reactionService.reactToPost(treeId, postId, request, token));
     }
 
     @PostMapping("/trees/{treeId}/feed/comments/{commentId}/reaction")
     @Operation(summary = "댓글 리액션", description = "댓글에 리액션을 추가합니다.")
-    public ApiResponse createCommentReaction(
+    public ApiResponse<ReactionResponseDTO.addReaction> createCommentReaction(
             @PathVariable Long treeId,
             @PathVariable Long commentId,
             @RequestHeader("Authorization") String header,
             @RequestBody ReactionRequestDTO.createReaction request
     ) {
         String token = header.replace("Bearer ", "");
-        reactionService.reactToComment(treeId, commentId, request, token);
-        return ApiResponse.onSuccess("");
+        return ApiResponse.onSuccess(reactionService.reactToComment(treeId, commentId, request, token));
     }
 
     @PostMapping("/trees/{treeId}/feed/replies/{replyId}/reaction")
     @Operation(summary = "답글 리액션", description = "답글에 리액션을 추가합니다.")
-    public ApiResponse createReplyReaction(
+    public ApiResponse<ReactionResponseDTO.addReaction> createReplyReaction(
             @PathVariable Long treeId,
             @PathVariable Long replyId,
             @RequestHeader("Authorization") String header,
             @RequestBody ReactionRequestDTO.createReaction request
     ) {
         String token = header.replace("Bearer ", "");
-        reactionService.reactToReply(treeId, replyId, request, token);
-        return ApiResponse.onSuccess("");
+        return ApiResponse.onSuccess(reactionService.reactToReply(treeId, replyId, request, token));
     }
 
 

--- a/src/main/java/org/example/tree/domain/reaction/converter/ReactionConverter.java
+++ b/src/main/java/org/example/tree/domain/reaction/converter/ReactionConverter.java
@@ -27,6 +27,13 @@ public class ReactionConverter {
                 .build();
     }
 
+    public ReactionResponseDTO.addReaction toAddReaction(ReactionType type, Integer count) {
+        return ReactionResponseDTO.addReaction.builder()
+                .type(type.name())
+                .count(count)
+                .build();
+    }
+
     public Reaction toReplyReaction(Profile profile, Long replyId, ReactionType type) {
         return Reaction.builder()
                 .profile(profile)

--- a/src/main/java/org/example/tree/domain/reaction/dto/ReactionResponseDTO.java
+++ b/src/main/java/org/example/tree/domain/reaction/dto/ReactionResponseDTO.java
@@ -5,6 +5,15 @@ import lombok.*;
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 
 public class ReactionResponseDTO {
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class addReaction {
+        private String type;
+        private Integer count;
+    }
     @Builder
     @Getter
     @NoArgsConstructor

--- a/src/main/java/org/example/tree/domain/reaction/repository/ReactionRepository.java
+++ b/src/main/java/org/example/tree/domain/reaction/repository/ReactionRepository.java
@@ -21,4 +21,8 @@ public interface ReactionRepository extends JpaRepository<Reaction, Long> {
     Boolean existsByTargetIdAndTargetTypeAndTypeAndProfile(Long postId, TargetType targetType, ReactionType type, Profile profile);
 
     void deleteByTargetIdAndTargetTypeAndTypeAndProfile(Long postId, TargetType targetType, ReactionType type, Profile profile);
+
+    @Query("SELECT COUNT(r) FROM Reaction r WHERE r.targetId = :targetId AND r.targetType = :targetType AND r.type = :type")
+    Integer countReactionsByTypeAndTargetIdAndTargetType(@Param("type") ReactionType type, @Param("targetId") Long targetId, @Param("targetType") TargetType targetType);
+
 }

--- a/src/main/java/org/example/tree/domain/reaction/service/ReactionCommandService.java
+++ b/src/main/java/org/example/tree/domain/reaction/service/ReactionCommandService.java
@@ -13,8 +13,8 @@ import org.springframework.stereotype.Service;
 public class ReactionCommandService {
 
     private final ReactionRepository reactionRepository;
-    public void reactToPost(Reaction reaction) {
-        reactionRepository.save(reaction);
+    public Reaction reactToPost(Reaction reaction) {
+        return reactionRepository.save(reaction);
     }
 
     public void unReactToPost(Long postId, Profile profile, ReactionType type) {

--- a/src/main/java/org/example/tree/domain/reaction/service/ReactionQueryService.java
+++ b/src/main/java/org/example/tree/domain/reaction/service/ReactionQueryService.java
@@ -30,5 +30,9 @@ public class ReactionQueryService {
         return countsByType;
     }
 
+    public Integer getReactionCount(Long targetId, TargetType targetType, ReactionType type) {
+        return reactionRepository.countReactionsByTypeAndTargetIdAndTargetType(type, targetId, targetType);
+    }
+
 
 }

--- a/src/main/java/org/example/tree/domain/reaction/service/ReactionService.java
+++ b/src/main/java/org/example/tree/domain/reaction/service/ReactionService.java
@@ -36,16 +36,19 @@ public class ReactionService {
     private final ReactionRepository reactionRepository;
 
     @Transactional
-    public void reactToPost(Long treeId, Long postId, ReactionRequestDTO.createReaction request, String token) {
+    public ReactionResponseDTO.addReaction reactToPost(Long treeId, Long postId, ReactionRequestDTO.createReaction request, String token) {
         Profile profile = profileService.getTreeProfile(token, treeId);
         Post Post = postQueryService.findById(postId);
         Boolean isPushed =reactionRepository.existsByTargetIdAndTargetTypeAndTypeAndProfile(postId, TargetType.POST, request.getType(), profile);
         if(isPushed){
             reactionCommandService.unReactToPost(postId, profile, request.getType());
-            return;
+            Integer countAfterUnreact = reactionQueryService.getReactionCount(postId, TargetType.POST, request.getType());
+            return reactionConverter.toAddReaction(request.getType(), countAfterUnreact);
         }
         Reaction reaction = reactionConverter.toPostReaction(profile, postId, request.getType());
         reactionCommandService.reactToPost(reaction);
+        Integer count = reactionQueryService.getReactionCount(postId, TargetType.POST, request.getType());
+        return reactionConverter.toAddReaction(request.getType(), count);
     }
 
     @Transactional
@@ -63,16 +66,19 @@ public class ReactionService {
     }
 
     @Transactional
-    public void reactToComment(Long treeId, Long commentId, ReactionRequestDTO.createReaction request, String token) {
+    public ReactionResponseDTO.addReaction reactToComment(Long treeId, Long commentId, ReactionRequestDTO.createReaction request, String token) {
         Profile profile = profileService.getTreeProfile(token, treeId);
         Comment comment = commentQueryService.findById(commentId);
         Boolean isPushed =reactionRepository.existsByTargetIdAndTargetTypeAndTypeAndProfile(commentId, TargetType.COMMENT, request.getType(), profile);
         if(isPushed){
             reactionCommandService.unReactToComment(commentId, profile, request.getType());
-            return;
+            Integer countAfterUnreact = reactionQueryService.getReactionCount(commentId, TargetType.COMMENT, request.getType());
+            return reactionConverter.toAddReaction(request.getType(), countAfterUnreact);
         }
         Reaction reaction = reactionConverter.toCommentReaction(profile, commentId, request.getType());
-        reactionCommandService.reactToComment(reaction);
+        reactionCommandService.reactToPost(reaction);
+        Integer count = reactionQueryService.getReactionCount(commentId, TargetType.COMMENT, request.getType());
+        return reactionConverter.toAddReaction(request.getType(), count);
     }
 
     @Transactional
@@ -90,16 +96,19 @@ public class ReactionService {
     }
 
     @Transactional
-    public void reactToReply(Long treeId, Long replyId, ReactionRequestDTO.createReaction request, String token) {
+    public ReactionResponseDTO.addReaction reactToReply(Long treeId, Long replyId, ReactionRequestDTO.createReaction request, String token) {
         Profile profile = profileService.getTreeProfile(token, treeId);
         Reply reply = replyQueryService.findById(replyId);
         Boolean isPushed =reactionRepository.existsByTargetIdAndTargetTypeAndTypeAndProfile(replyId, TargetType.REPLY, request.getType(), profile);
         if(isPushed){
             reactionCommandService.unReactToReply(replyId, profile, request.getType());
-            return;
+            Integer countAfterUnreact = reactionQueryService.getReactionCount(replyId, TargetType.REPLY, request.getType());
+            return reactionConverter.toAddReaction(request.getType(), countAfterUnreact);
         }
         Reaction reaction = reactionConverter.toReplyReaction(profile, replyId, request.getType());
-        reactionCommandService.reactToReply(reaction);
+        reactionCommandService.reactToPost(reaction);
+        Integer count = reactionQueryService.getReactionCount(replyId, TargetType.REPLY, request.getType());
+        return reactionConverter.toAddReaction(request.getType(), count);
     }
 
     @Transactional


### PR DESCRIPTION
# 🚀 개요
<!-- 이 PR을 간략하게 설명해주세요 -->
피드 관련 동작 시, 반환값 양식 수정
## 🔍 변경사항
<!-- 이 PR로 인해 바뀌게 되는 것들을 목록으로 적어주세요. -->
- 게시글, 댓글, 답글 조회 시, 작성자의 profileId(authorId) 출력
- 게시글 조회, 피드 조회 - 작성자와 현재 로그인한 멤버 간 branchDegree 출력
- 반응(Reaction) 추가/삭제 직후, 해당 타입의 반응 개수 출력

## ⏳ 작업 내용
- [x] 게시글,댓글,답글의 ResponseDTO에 authorId 필드를 추가
- [x] 게시글 조회 ResponseDTO에 branchDegree 필드 추가
- [x] 게시글 조회 서비스 로직에서 calculateBranchDegree 메서드 호출
- [x] reactTo~ 메서드에서 사용할 수 있도록 ReactionQueryService에 특정 타입의 반응의 개수 계산 로직 추가

### 📝 논의사항
<!-- 이 PR에 대한 논의하고 싶은 사항이나, 더 해야할 작업, 리뷰어에게 특별히 확인 요청하고 싶은 부분 등을 적어주세요. -->

