### PR TITLE
[REFACTOR]/#60-PostImage 생성 로직 수정

### DIFF
--- a/src/main/java/org/example/tree/domain/post/controller/PostController.java
+++ b/src/main/java/org/example/tree/domain/post/controller/PostController.java
@@ -19,11 +19,20 @@ public class PostController {
     private final PostService postService;
 
     @PostMapping(value = "/trees/{treeId}/feed/posts", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+<<<<<<< Updated upstream
     @Operation(summary = "게시글 작성", description = "게시글을 작성합니다.")
     public ApiResponse<PostResponseDTO.createPost> createPost(
             @PathVariable final Long treeId,
             @RequestHeader("Authorization") final String header,
             @RequestPart final PostRequestDTO.createPost request
+=======
+    public ApiResponse<PostResponseDTO.createPost> createPost(
+            @PathVariable final Long treeId,
+            @RequestHeader("Authorization") final String header,
+            @RequestPart(value="request") final PostRequestDTO.createPost request,
+            @RequestPart(value="images") final List<MultipartFile> images
+
+>>>>>>> Stashed changes
     ) throws Exception {
         String token = header.replace("Bearer ", "");
         return ApiResponse.onSuccess(postService.createPost(treeId, request, token));

--- a/src/main/java/org/example/tree/domain/post/dto/PostRequestDTO.java
+++ b/src/main/java/org/example/tree/domain/post/dto/PostRequestDTO.java
@@ -3,6 +3,10 @@ package org.example.tree.domain.post.dto;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+<<<<<<< Updated upstream
+=======
+import org.springframework.web.bind.annotation.RequestPart;
+>>>>>>> Stashed changes
 import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;

--- a/src/main/java/org/example/tree/domain/post/service/PostService.java
+++ b/src/main/java/org/example/tree/domain/post/service/PostService.java
@@ -36,8 +36,12 @@ public class PostService {
     private final BranchService branchService;
 
     @Transactional
+<<<<<<< Updated upstream
     public PostResponseDTO.createPost createPost(Long treeId, PostRequestDTO.createPost request, String token) throws Exception {
         List<MultipartFile> images = request.getImages() != null && !request.getImages().isEmpty() ? request.getImages() : new ArrayList<>();
+=======
+    public PostResponseDTO.createPost createPost(Long treeId, PostRequestDTO.createPost request, List<MultipartFile> images, String token) throws Exception {
+>>>>>>> Stashed changes
         Profile profile = profileService.getTreeProfile(token, treeId);
         List<PostImage> postImages = postConverter.toPostImages(images);
         Post post = postConverter.toPost(request.getContent(), profile);

--- a/src/main/java/org/example/tree/global/config/SwaggerConfig.java
+++ b/src/main/java/org/example/tree/global/config/SwaggerConfig.java
@@ -5,7 +5,10 @@ import io.swagger.v3.oas.models.info.Info;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.security.SecurityRequirement;
 import io.swagger.v3.oas.models.security.SecurityScheme;
+<<<<<<< Updated upstream
 import io.swagger.v3.oas.models.servers.Server;
+=======
+>>>>>>> Stashed changes
 import org.springdoc.core.models.GroupedOpenApi;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -24,16 +27,17 @@ public class SwaggerConfig {
 
     @Bean
     public OpenAPI openAPI() {
-        SecurityScheme securityScheme = new SecurityScheme()
-                .type(SecurityScheme.Type.HTTP).scheme("bearer").bearerFormat("JWT")
-                .in(SecurityScheme.In.HEADER).name("Authorization");
-        SecurityRequirement securityRequirement = new SecurityRequirement().addList("bearerAuth");
+            SecurityScheme securityScheme = new SecurityScheme()
+                    .type(SecurityScheme.Type.HTTP).scheme("bearer").bearerFormat("JWT")
+                    .in(SecurityScheme.In.HEADER).name("Authorization");
+            SecurityRequirement securityRequirement = new SecurityRequirement().addList("bearerAuth");
 
-        return new OpenAPI()
-                .components(new Components().addSecuritySchemes("bearerAuth", securityScheme))
-                .security(Arrays.asList(securityRequirement))
-                .servers(Arrays.asList(
-                        new Server().url("https://dev.tttree.shop").description("Develop server")));
+            return new OpenAPI()
+                    .components(new Components().addSecuritySchemes("bearerAuth", securityScheme))
+                    .security(Arrays.asList(securityRequirement))
+                    .info(new Info()
+                        .title("Tree API")
+                        .version("1.0.0"));
     }
 
 }


### PR DESCRIPTION
# 🚀 개요
<!-- 이 PR을 간략하게 설명해주세요 -->
게시글 생성 시, 이미지 관련 동작 수정

## 🔍 변경사항
<!-- 이 PR로 인해 바뀌게 되는 것들을 목록으로 적어주세요. -->
- 게시글에 이미지를 첨부한 경우를 고려할 때 RequestPart를 이용해 "images" 필드에 이미지를 담아 보내도록 유도

## ⏳ 작업 내용
- [x] **POST** /trees/1/feed/posts - 에서 이미지를 받아 저장하는 로직 수정

### 📝 논의사항
<!-- 이 PR에 대한 논의하고 싶은 사항이나, 더 해야할 작업, 리뷰어에게 특별히 확인 요청하고 싶은 부분 등을 적어주세요. -->

