### PR TITLE
[FEAT]: 초대장 조회 시, treeProfileImages 불러오는 로직 구현

### DIFF
--- a/src/main/java/org/example/tree/domain/invitation/converter/InvitationConverter.java
+++ b/src/main/java/org/example/tree/domain/invitation/converter/InvitationConverter.java
@@ -8,6 +8,7 @@ import org.example.tree.domain.tree.entity.Tree;
 import org.springframework.stereotype.Component;
 
 import java.util.ArrayList;
+import java.util.List;
 
 @Component
 public class InvitationConverter {
@@ -47,13 +48,13 @@ public class InvitationConverter {
                 .build();
     }
 
-    public InvitationResponseDTO.getInvitation toGetInvitation (Invitation invitation) {
+    public InvitationResponseDTO.getInvitation toGetInvitation (Invitation invitation, List<String> treeMemberProfileImages) {
         return InvitationResponseDTO.getInvitation.builder()
                 .invitationId(invitation.getId())
                 .treeName(invitation.getTree().getName())
                 .senderName(invitation.getSender().getMemberName())
                 .treeSize(invitation.getTree().getTreeSize())
-                .treeMemberProfileImages(new ArrayList<>())
+                .treeMemberProfileImages(treeMemberProfileImages)
                 .build();
     }
 }

--- a/src/main/java/org/example/tree/domain/invitation/service/InvitationService.java
+++ b/src/main/java/org/example/tree/domain/invitation/service/InvitationService.java
@@ -17,6 +17,7 @@ import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
@@ -80,7 +81,19 @@ public class InvitationService {
         Member member = memberQueryService.findByToken(token);
         List<Invitation> invitations= invitationQueryService.findAllByPhone(member.getPhone());
         return invitations.stream()
-                .map(invitationConverter::toGetInvitation)
+                .map(invitation -> {
+                    Tree tree = invitation.getTree(); // Invitation에서 Tree 정보를 가져옵니다.
+                    List<Profile> treeMembers = profileQueryService.findTreeMembers(tree); // Tree의 모든 멤버를 조회합니다.
+
+                    // treeMembers에서 무작위로 3명의 멤버를 선택합니다. (멤버 수가 3명 미만인 경우 모든 멤버를 선택)
+                    List<String> randomProfileImages = treeMembers.stream()
+                            .map(Profile::getProfileImageUrl)
+                            .limit(3) // 최대 3명
+                            .collect(Collectors.toList());
+
+                    // toGetInvitation 메소드를 수정하여, 선택된 멤버의 profileImage 정보를 포함시켜야 합니다.
+                    return invitationConverter.toGetInvitation(invitation, randomProfileImages);
+                })
                 .collect(Collectors.toList());
     }
 }

--- a/src/main/java/org/example/tree/domain/profile/repository/ProfileRepository.java
+++ b/src/main/java/org/example/tree/domain/profile/repository/ProfileRepository.java
@@ -16,4 +16,5 @@ public interface ProfileRepository extends JpaRepository<Profile, Long> {
 
     List<Profile> findAllByMember_Id(String memberId);
 
+    List<Profile> findAllByTree(Tree tree);
 }

--- a/src/main/java/org/example/tree/domain/profile/service/ProfileQueryService.java
+++ b/src/main/java/org/example/tree/domain/profile/service/ProfileQueryService.java
@@ -33,4 +33,8 @@ public class ProfileQueryService {
                 .map(foundProfile -> foundProfile.getTree().getId())
                 .toList();
     }
+
+    public List<Profile> findTreeMembers(Tree tree) {
+        return profileRepository.findAllByTree(tree);
+    }
 }

--- a/src/main/java/org/example/tree/domain/tree/entity/Tree.java
+++ b/src/main/java/org/example/tree/domain/tree/entity/Tree.java
@@ -18,7 +18,7 @@ public class Tree extends BaseDateTimeEntity {
     private String name;
 
     @Builder.Default
-    private Integer treeSize = 1; //트리 규모(총 인원)
+    private Integer treeSize = 0; //트리 규모(총 인원)
 
     public void increaseTreeSize() {
         this.treeSize++;

--- a/src/main/java/org/example/tree/global/config/SwaggerConfig.java
+++ b/src/main/java/org/example/tree/global/config/SwaggerConfig.java
@@ -5,6 +5,7 @@ import io.swagger.v3.oas.models.info.Info;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.security.SecurityRequirement;
 import io.swagger.v3.oas.models.security.SecurityScheme;
+import io.swagger.v3.oas.models.servers.Server;
 import org.springdoc.core.models.GroupedOpenApi;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -31,6 +32,8 @@ public class SwaggerConfig {
             return new OpenAPI()
                     .components(new Components().addSecuritySchemes("bearerAuth", securityScheme))
                     .security(Arrays.asList(securityRequirement))
+                    .servers(Arrays.asList(
+                            new Server().url("https://dev.tttree.shop").description("Develop server")))
                     .info(new Info()
                         .title("Tree API")
                         .version("1.0.0"));


### PR DESCRIPTION
# 🚀 개요
<!-- 이 PR을 간략하게 설명해주세요 -->
내가 받은 초대장 조회 시, treeProfileImages 불러오는 로직 구현

## 🔍 변경사항
<!-- 이 PR로 인해 바뀌게 되는 것들을 목록으로 적어주세요. -->
- treeProfileImages에 최대 3며의 TreeHouse멤버의 프로필 이미지 추가

## ⏳ 작업 내용
- [x] **GET** /users/invitation - treeProfileImages 필드에 프로필 이미지 링크들 추가
### 📝 논의사항
<!-- 이 PR에 대한 논의하고 싶은 사항이나, 더 해야할 작업, 리뷰어에게 특별히 확인 요청하고 싶은 부분 등을 적어주세요. -->

