### PR TITLE
Feature/64-트리하우스 목록 조회 및 변경 API 조회

### DIFF
--- a/src/main/java/org/example/tree/domain/profile/converter/ProfileConverter.java
+++ b/src/main/java/org/example/tree/domain/profile/converter/ProfileConverter.java
@@ -18,6 +18,7 @@ public class ProfileConverter {
                 .memberName(memberName)
                 .bio(bio)
                 .profileImageUrl(profileImageUrl)
+                .isActive(true)
                 .build();
     }
 

--- a/src/main/java/org/example/tree/domain/profile/entity/Profile.java
+++ b/src/main/java/org/example/tree/domain/profile/entity/Profile.java
@@ -22,10 +22,16 @@ public class Profile extends BaseDateTimeEntity {
 
     private String profileImageUrl; //프로필 이미지(트리 별로 상이)
 
+    private boolean isActive; //현재 선택한 트리의 프로필인지 여부
+
     @JoinColumn(name = "memberId")
     @ManyToOne(fetch = FetchType.LAZY)
     private Member member;
     @JoinColumn(name = "treeId")
     @ManyToOne(fetch = FetchType.LAZY)
     private Tree tree;
+
+    public void inactivate() {
+        this.isActive = false;
+    }
 }

--- a/src/main/java/org/example/tree/domain/profile/entity/Profile.java
+++ b/src/main/java/org/example/tree/domain/profile/entity/Profile.java
@@ -31,6 +31,9 @@ public class Profile extends BaseDateTimeEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     private Tree tree;
 
+    public void actvate() {
+        this.isActive = true;
+    }
     public void inactivate() {
         this.isActive = false;
     }

--- a/src/main/java/org/example/tree/domain/profile/repository/ProfileRepository.java
+++ b/src/main/java/org/example/tree/domain/profile/repository/ProfileRepository.java
@@ -22,4 +22,7 @@ public interface ProfileRepository extends JpaRepository<Profile, Long> {
 
     @Query("SELECT p FROM Profile p WHERE p.member = :member AND p.isActive = TRUE")
     Optional<Profile> findCurrentProfile(@Param("member") Member member);
+
+    @Query("SELECT COUNT(p) = 0 FROM Profile p WHERE p.member = :member AND p.isActive = TRUE")
+    boolean existsActiveProfileByMember(@Param("member") Member member);
 }

--- a/src/main/java/org/example/tree/domain/profile/repository/ProfileRepository.java
+++ b/src/main/java/org/example/tree/domain/profile/repository/ProfileRepository.java
@@ -4,6 +4,8 @@ import org.example.tree.domain.member.entity.Member;
 import org.example.tree.domain.profile.entity.Profile;
 import org.example.tree.domain.tree.entity.Tree;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -17,4 +19,7 @@ public interface ProfileRepository extends JpaRepository<Profile, Long> {
     List<Profile> findAllByMember_Id(String memberId);
 
     List<Profile> findAllByTree(Tree tree);
+
+    @Query("SELECT p FROM Profile p WHERE p.member = :member AND p.isActive = TRUE")
+    Optional<Profile> findCurrentProfile(@Param("member") Member member);
 }

--- a/src/main/java/org/example/tree/domain/profile/service/ProfileCommandService.java
+++ b/src/main/java/org/example/tree/domain/profile/service/ProfileCommandService.java
@@ -12,4 +12,8 @@ public class ProfileCommandService {
     public void createProfile(Profile profile) {
         profileRepository.save(profile);
     }
+
+    public void updateProfile(Profile profile) {
+        profileRepository.save(profile);
+    }
 }

--- a/src/main/java/org/example/tree/domain/profile/service/ProfileQueryService.java
+++ b/src/main/java/org/example/tree/domain/profile/service/ProfileQueryService.java
@@ -42,4 +42,8 @@ public class ProfileQueryService {
         return profileRepository.findCurrentProfile(member)
                 .orElseThrow(() -> new GeneralException(GlobalErrorCode.AVAILABLE_PROFILE_NOT_FOUND));
     }
+
+    public boolean isNewUser(Member member) {
+        return profileRepository.existsActiveProfileByMember(member);
+    }
 }

--- a/src/main/java/org/example/tree/domain/profile/service/ProfileQueryService.java
+++ b/src/main/java/org/example/tree/domain/profile/service/ProfileQueryService.java
@@ -37,4 +37,9 @@ public class ProfileQueryService {
     public List<Profile> findTreeMembers(Tree tree) {
         return profileRepository.findAllByTree(tree);
     }
+
+    public Profile getCurrentProfile(Member member) {
+        return profileRepository.findCurrentProfile(member)
+                .orElseThrow(() -> new GeneralException(GlobalErrorCode.AVAILABLE_PROFILE_NOT_FOUND));
+    }
 }

--- a/src/main/java/org/example/tree/domain/profile/service/ProfileService.java
+++ b/src/main/java/org/example/tree/domain/profile/service/ProfileService.java
@@ -37,6 +37,12 @@ public class ProfileService {
     public ProfileResponseDTO.createProfile createProfile(ProfileRequestDTO.createProfile request, MultipartFile profileImage) throws Exception {
         Tree tree = treeQueryService.findById(request.getTreeId());
         Member member = memberQueryService.findById(request.getUserId());
+        boolean isNewUser = profileQueryService.isNewUser(member);
+        if (!isNewUser) {
+            Profile currentProfile = profileQueryService.getCurrentProfile(member);
+            currentProfile.inactivate();
+            profileCommandService.updateProfile(currentProfile);
+        }
         String profileImageUrl = !profileImage.isEmpty() ? s3UploadService.uploadImage(profileImage) : DEFAULT_PROFILE_IMAGE;
         Profile newProfile = profileConverter.toProfile(tree, member, request.getMemberName(), request.getBio(), profileImageUrl);
         profileCommandService.createProfile(newProfile);
@@ -51,6 +57,12 @@ public class ProfileService {
     public ProfileResponseDTO.createProfile ownerProfile(ProfileRequestDTO.ownerProfile request, MultipartFile profileImage) throws Exception {
         Tree tree = treeQueryService.findById(request.getTreeId());
         Member member = memberQueryService.findById(request.getUserId());
+        boolean isNewUser = profileQueryService.isNewUser(member);
+        if (!isNewUser) {
+            Profile currentProfile = profileQueryService.getCurrentProfile(member);
+            currentProfile.inactivate();
+            profileCommandService.updateProfile(currentProfile);
+        }
         String profileImageUrl = !profileImage.isEmpty() ? s3UploadService.uploadImage(profileImage) : DEFAULT_PROFILE_IMAGE;
         Profile newProfile = profileConverter.toProfile(tree, member, request.getMemberName(), request.getBio(), profileImageUrl);
         profileCommandService.createProfile(newProfile);

--- a/src/main/java/org/example/tree/domain/profile/service/ProfileService.java
+++ b/src/main/java/org/example/tree/domain/profile/service/ProfileService.java
@@ -7,7 +7,6 @@ import org.example.tree.domain.invitation.entity.Invitation;
 import org.example.tree.domain.invitation.service.InvitationQueryService;
 import org.example.tree.domain.member.entity.Member;
 import org.example.tree.domain.member.service.MemberQueryService;
-import org.example.tree.domain.post.service.PostService;
 import org.example.tree.domain.profile.converter.ProfileConverter;
 import org.example.tree.domain.profile.dto.ProfileRequestDTO;
 import org.example.tree.domain.profile.dto.ProfileResponseDTO;

--- a/src/main/java/org/example/tree/domain/tree/controller/TreeController.java
+++ b/src/main/java/org/example/tree/domain/tree/controller/TreeController.java
@@ -1,14 +1,14 @@
 package org.example.tree.domain.tree.controller;
 
+import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import org.example.tree.domain.tree.dto.TreeRequestDTO;
 import org.example.tree.domain.tree.dto.TreeResponseDTO;
 import org.example.tree.domain.tree.service.TreeService;
 import org.example.tree.global.common.ApiResponse;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
@@ -16,12 +16,23 @@ import org.springframework.web.bind.annotation.RestController;
 public class TreeController {
     private final TreeService treeService;
 
+    @Operation(summary = "트리하우스 등록")
     @PostMapping("/register")
     public ApiResponse createTree(
             @RequestBody TreeRequestDTO.createTree request
     ) {
         treeService.createTree(request);
         return ApiResponse.onSuccess("");
+    }
+
+    @Operation(summary = "트리하우스 조회")
+    @GetMapping
+    public ApiResponse<List<TreeResponseDTO.getTree>> getTrees(
+            @RequestHeader("Authorization") final String header
+    )
+     {
+         String token = header.replace("Bearer ", "");
+         return ApiResponse.onSuccess(treeService.getTrees(token));
     }
 
 

--- a/src/main/java/org/example/tree/domain/tree/controller/TreeController.java
+++ b/src/main/java/org/example/tree/domain/tree/controller/TreeController.java
@@ -35,5 +35,14 @@ public class TreeController {
          return ApiResponse.onSuccess(treeService.getTrees(token));
     }
 
+    @Operation(summary = "트리하우스 위치 변경")
+    @PostMapping("/{treeId}")
+    public ApiResponse<TreeResponseDTO.shiftTree> shiftTree(
+            @RequestHeader("Authorization") final String header,
+            @PathVariable final Long treeId
+    ) {
+        String token = header.replace("Bearer ", "");
+        return ApiResponse.onSuccess(treeService.shiftTree(treeId, token));
+    }
 
 }

--- a/src/main/java/org/example/tree/domain/tree/converter/TreeConverter.java
+++ b/src/main/java/org/example/tree/domain/tree/converter/TreeConverter.java
@@ -25,4 +25,10 @@ public class TreeConverter {
                 .isSelected(isSelected)
                 .build();
     }
+
+    public TreeResponseDTO.shiftTree toShiftTree(Tree tree) {
+        return TreeResponseDTO.shiftTree.builder()
+                .treeId(tree.getId())
+                .build();
+    }
 }

--- a/src/main/java/org/example/tree/domain/tree/converter/TreeConverter.java
+++ b/src/main/java/org/example/tree/domain/tree/converter/TreeConverter.java
@@ -1,13 +1,28 @@
 package org.example.tree.domain.tree.converter;
 
+import org.example.tree.domain.profile.entity.Profile;
+import org.example.tree.domain.tree.dto.TreeResponseDTO;
 import org.example.tree.domain.tree.entity.Tree;
 import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Component
 public class TreeConverter {
     public Tree toTree (String name) {
         return Tree.builder()
                 .name(name)
+                .build();
+    }
+
+    public TreeResponseDTO.getTree toGetTree(Tree tree, List<String> treeMemberProfileImages, Profile currentProfile) {
+        Boolean isSelected = currentProfile.getTree().getId().equals(tree.getId());
+        return TreeResponseDTO.getTree.builder()
+                .treeName(tree.getName())
+                .treeSize(tree.getTreeSize())
+                .treeMemberProfileImages(treeMemberProfileImages)
+                .isSelected(isSelected)
                 .build();
     }
 }

--- a/src/main/java/org/example/tree/domain/tree/dto/TreeResponseDTO.java
+++ b/src/main/java/org/example/tree/domain/tree/dto/TreeResponseDTO.java
@@ -1,13 +1,19 @@
 package org.example.tree.domain.tree.dto;
 
-import lombok.AccessLevel;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
+
+import java.util.List;
 
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class TreeResponseDTO {
-//    @Getter
-//    public static class registerTree {
-//        private String treeName;
-//    }
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class getTree {
+        private String treeName;
+        private Integer treeSize;
+        private List<String> treeMemberProfileImages;
+        private Boolean isSelected;
+    }
 }

--- a/src/main/java/org/example/tree/domain/tree/dto/TreeResponseDTO.java
+++ b/src/main/java/org/example/tree/domain/tree/dto/TreeResponseDTO.java
@@ -16,4 +16,12 @@ public class TreeResponseDTO {
         private List<String> treeMemberProfileImages;
         private Boolean isSelected;
     }
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class shiftTree {
+        private Long treeId;
+    }
 }

--- a/src/main/java/org/example/tree/domain/tree/service/TreeQueryService.java
+++ b/src/main/java/org/example/tree/domain/tree/service/TreeQueryService.java
@@ -1,11 +1,14 @@
 package org.example.tree.domain.tree.service;
 
 import lombok.RequiredArgsConstructor;
+import org.example.tree.domain.member.entity.Member;
 import org.example.tree.domain.tree.entity.Tree;
 import org.example.tree.domain.tree.repository.TreeRepository;
 import org.example.tree.global.exception.GeneralException;
 import org.example.tree.global.exception.GlobalErrorCode;
 import org.springframework.stereotype.Service;
+
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -16,4 +19,5 @@ public class TreeQueryService {
         return treeRepository.findById(id)
                 .orElseThrow(()->new GeneralException(GlobalErrorCode.TREE_NOT_FOUND));
     }
+
 }

--- a/src/main/java/org/example/tree/domain/tree/service/TreeService.java
+++ b/src/main/java/org/example/tree/domain/tree/service/TreeService.java
@@ -30,6 +30,7 @@ public class TreeService {
         treeCommandService.createTree(tree);
     }
 
+    @Transactional
     public List<TreeResponseDTO.getTree> getTrees(String token) {
         Member member = memberQueryService.findByToken(token);
         Profile currentProfile = profileQueryService.getCurrentProfile(member);

--- a/src/main/java/org/example/tree/domain/tree/service/TreeService.java
+++ b/src/main/java/org/example/tree/domain/tree/service/TreeService.java
@@ -3,10 +3,17 @@ package org.example.tree.domain.tree.service;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.example.tree.domain.member.entity.Member;
+import org.example.tree.domain.member.service.MemberQueryService;
+import org.example.tree.domain.profile.entity.Profile;
+import org.example.tree.domain.profile.service.ProfileQueryService;
 import org.example.tree.domain.tree.converter.TreeConverter;
 import org.example.tree.domain.tree.dto.TreeRequestDTO;
+import org.example.tree.domain.tree.dto.TreeResponseDTO;
 import org.example.tree.domain.tree.entity.Tree;
 import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Component
 @RequiredArgsConstructor
@@ -14,6 +21,8 @@ public class TreeService {
     private final TreeCommandService treeCommandService;
     private final TreeQueryService treeQueryService;
     private final TreeConverter treeConverter;
+    private final MemberQueryService memberQueryService;
+    private final ProfileQueryService profileQueryService;
 
     @Transactional
     public void createTree(TreeRequestDTO.createTree request) {
@@ -21,4 +30,22 @@ public class TreeService {
         treeCommandService.createTree(tree);
     }
 
+    public List<TreeResponseDTO.getTree> getTrees(String token) {
+        Member member = memberQueryService.findByToken(token);
+        Profile currentProfile = profileQueryService.getCurrentProfile(member);
+        List<Long> treeIds = profileQueryService.findJoinedTree(currentProfile);
+        List<Tree> trees = treeIds.stream()
+                .map(treeQueryService::findById)
+                .collect(Collectors.toList());
+        return  trees.stream()
+                .map(tree -> {
+                    List<Profile> treeMembers = profileQueryService.findTreeMembers(tree); // Tree의 모든 멤버를 조회합니다.
+                    List<String> randomProfileImages = treeMembers.stream()
+                            .map(Profile::getProfileImageUrl)
+                            .limit(3) // 최대 3명
+                            .collect(Collectors.toList());
+                    return treeConverter.toGetTree(tree, randomProfileImages, currentProfile);
+                })
+                .collect(Collectors.toList());
+    }
 }

--- a/src/main/java/org/example/tree/domain/tree/service/TreeService.java
+++ b/src/main/java/org/example/tree/domain/tree/service/TreeService.java
@@ -49,4 +49,16 @@ public class TreeService {
                 })
                 .collect(Collectors.toList());
     }
+
+    @Transactional
+    public TreeResponseDTO.shiftTree shiftTree(Long treeId, String token) {
+        Member member = memberQueryService.findByToken(token);
+        Tree tree = treeQueryService.findById(treeId);
+        Profile currentProfile = profileQueryService.getCurrentProfile(member);
+        currentProfile.inactivate();
+        Profile shiftedProfile = profileQueryService.getTreeProfile(member, tree);
+        shiftedProfile.actvate();
+        return treeConverter.toShiftTree(tree);
+
+    }
 }

--- a/src/main/java/org/example/tree/global/exception/GlobalErrorCode.java
+++ b/src/main/java/org/example/tree/global/exception/GlobalErrorCode.java
@@ -27,6 +27,7 @@ public enum GlobalErrorCode {
     //Profile
     //404 Not Found - 찾을 수 없음
     PROFILE_NOT_FOUND(NOT_FOUND, "존재하지 않는 프로필입니다."),
+    AVAILABLE_PROFILE_NOT_FOUND(NOT_FOUND, "현재 선택된 프로필이 없습니다."),
 
     //Tree
     //404 Not Found - 찾을 수 없음
@@ -54,7 +55,8 @@ public enum GlobalErrorCode {
 
     //Notification
     //404 Not Found - 찾을 수 없음
-    NOTIFICATION_NOT_FOUND(NOT_FOUND, "알림이 없습니다.");
+    NOTIFICATION_NOT_FOUND(NOT_FOUND, "알림이 없습니다."),
+    ;
 
 
 


### PR DESCRIPTION
# 🚀 개요
<!-- 이 PR을 간략하게 설명해주세요 -->
현재 사용자가 속해 있는 트리하우스들의 목록을 조회하고 선택하여 입장하는 API 구현

## 🔍 변경사항
<!-- 이 PR로 인해 바뀌게 되는 것들을 목록으로 적어주세요. -->
- 트리하우스에 신규 가입을 한 경우, 이미 가입된 트리하우스가 있는 지 조사하는 절차 추가
- 이미 가입된 트리하우스가 있는 경우, 트리하우스 가입과 동시에 Profile을 '활성화' 하여 현재 선택한 트리하우스로 지정
- 트리하우스들의 목록을 조회할 때, 현재 선택한 트리하우스가 무엇인지 반환 (`isSelected`)
- 트리하우스를 선택하여 입장할 때, 자동으로 선택한 트리하우스도 변경되도록 설정

## ⏳ 작업 내용
- [x] **POST** /trees/{treeId} - 트리하우스 선택/변경
- [x] **GET** /trees - 사용자가 속한 모든 트리하우스 목록 조회

### 📝 논의사항
<!-- 이 PR에 대한 논의하고 싶은 사항이나, 더 해야할 작업, 리뷰어에게 특별히 확인 요청하고 싶은 부분 등을 적어주세요. -->

