### PR TITLE
[FEAT]/#68-피드조회 시, treeId, treeName 함께 반환

### DIFF
--- a/src/main/java/org/example/tree/domain/post/controller/PostController.java
+++ b/src/main/java/org/example/tree/domain/post/controller/PostController.java
@@ -31,7 +31,7 @@ public class PostController {
 
     @GetMapping("/trees/{treeId}/feed")
     @Operation(summary = "피드 조회", description = "특정 트리하우스 속 피드를 불러옵니다.")
-    public ApiResponse<List<PostResponseDTO.getFeed>> getFeed(
+    public ApiResponse<PostResponseDTO.getFeed> getFeed(
             @PathVariable final Long treeId,
             @RequestHeader("Authorization") final String header
     ) {

--- a/src/main/java/org/example/tree/domain/post/converter/PostConverter.java
+++ b/src/main/java/org/example/tree/domain/post/converter/PostConverter.java
@@ -7,6 +7,7 @@ import org.example.tree.domain.post.entity.Post;
 import org.example.tree.domain.post.entity.PostImage;
 import org.example.tree.domain.profile.entity.Profile;
 import org.example.tree.domain.reaction.dto.ReactionResponseDTO;
+import org.example.tree.domain.tree.entity.Tree;
 import org.example.tree.global.common.amazons3.S3UploadService;
 import org.springframework.stereotype.Component;
 import org.springframework.web.multipart.MultipartFile;
@@ -44,21 +45,11 @@ public class PostConverter {
                 .build();
     }
 
-    public PostResponseDTO.getFeed toGetFeed(Post post, int branchDegree, List<ReactionResponseDTO.getReaction> reactions) {
-        List<String> imageUrls = post.getPostImages().stream()
-                .map(PostImage::getImageUrl)
-                .collect(Collectors.toList());
+    public PostResponseDTO.getFeed toGetFeed(Tree tree, List<PostResponseDTO.getPost> posts) {
         return PostResponseDTO.getFeed.builder()
-                .postId(post.getId())
-                .authorId(post.getProfile().getId())
-                .profileImageUrl(post.getProfile().getProfileImageUrl())
-                .memberName(post.getProfile().getMemberName())
-                .branchDegree(branchDegree)
-                .content(post.getContent())
-                .postImageUrls(imageUrls)
-                .createdAt(post.getCreatedAt())
-                .reactions(reactions)
-                .commentCount(post.getCommentCount())
+                .treeId(tree.getId())
+                .treeName(tree.getName())
+                .posts(posts)
                 .build();
     }
 

--- a/src/main/java/org/example/tree/domain/post/dto/PostResponseDTO.java
+++ b/src/main/java/org/example/tree/domain/post/dto/PostResponseDTO.java
@@ -26,17 +26,9 @@ public class PostResponseDTO {
     @NoArgsConstructor
     @AllArgsConstructor
     public static class getFeed {
-
-        private Long postId;
-        private Long authorId;
-        private String profileImageUrl;
-        private String memberName;
-        private int branchDegree;
-        private String content;
-        private List<String> postImageUrls;
-        private LocalDateTime createdAt;
-        private Integer commentCount;
-        private List<ReactionResponseDTO.getReaction> reactions;
+        private Long treeId;
+        private String treeName;
+        private List<PostResponseDTO.getPost> posts;
 
     }
 

--- a/src/main/java/org/example/tree/domain/post/service/PostService.java
+++ b/src/main/java/org/example/tree/domain/post/service/PostService.java
@@ -50,19 +50,20 @@ public class PostService {
     }
 
     @Transactional
-    public List<PostResponseDTO.getFeed> getFeed(Long treeId, String token) {
+    public PostResponseDTO.getFeed getFeed(Long treeId, String token) {
         Profile profile = profileService.getTreeProfile(token, treeId);
         List<Post> posts = postQueryService.getPosts(profile.getTree());
-        return posts.stream()
+        List<PostResponseDTO.getPost> treePosts = posts.stream()
                 .map(post -> {
                     // 작성자와의 branch degree를 가져옵니다.
                     int branchDegree = branchService.calculateBranchDegree(treeId, profile.getId(), post.getProfile().getId());
                     // 각 포스트에 대한 반응들을 가져옵니다.
                     List<ReactionResponseDTO.getReaction> reactions = reactionService.getPostReactions(treeId, post.getId(), token);
                     // Post와 해당 Post의 반응들을 포함하여 DTO를 생성합니다.
-                    return postConverter.toGetFeed(post, branchDegree, reactions);
+                    return postConverter.toGetPost(post, branchDegree, reactions);
                 })
                 .collect(Collectors.toList());
+        return postConverter.toGetFeed(profile.getTree(),treePosts);
     }
 
     @Transactional


### PR DESCRIPTION
# 🚀 개요
<!-- 이 PR을 간략하게 설명해주세요 -->
피드 조회 동작 실행 시, 트리하우스의 id(treeId), 트리하우스 이름(treeName)도 함께 반환하도록 추가했습니다.

## 🔍 변경사항
<!-- 이 PR로 인해 바뀌게 되는 것들을 목록으로 적어주세요. -->
- PostResponseDTO의 getFeed 호출 시, treeId, treeName 필드 추가
- 기존의 Post 정보들을 담던 필드를 리스트 형태의 DTO로 모아 getFeed DTO의 필드로써 존재하도록 변경

## ⏳ 작업 내용
- [x] **GET** /trees/{treeId}/feed 의 반환 DTO를 리스트 형태가 아닌 하나의 getFeed DTO로 변경

### 📝 논의사항
<!-- 이 PR에 대한 논의하고 싶은 사항이나, 더 해야할 작업, 리뷰어에게 특별히 확인 요청하고 싶은 부분 등을 적어주세요. -->

