### PR TITLE
Refactor/72 - 이미지 업로드 방식의 변경

### DIFF
--- a/src/main/java/org/example/tree/domain/post/controller/PostController.java
+++ b/src/main/java/org/example/tree/domain/post/controller/PostController.java
@@ -18,15 +18,14 @@ import java.util.List;
 public class PostController {
     private final PostService postService;
 
-    @PostMapping(value = "/trees/{treeId}/feed/posts", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    @PostMapping("/trees/{treeId}/feed/posts")
     public ApiResponse<PostResponseDTO.createPost> createPost(
             @PathVariable final Long treeId,
             @RequestHeader("Authorization") final String header,
-            @RequestPart(value="request") final PostRequestDTO.createPost request,
-            @RequestPart(value="images") final List<MultipartFile> images
+            @RequestBody final PostRequestDTO.createPost request
     ) throws Exception {
         String token = header.replace("Bearer ", "");
-        return ApiResponse.onSuccess(postService.createPost(treeId, request, images, token));
+        return ApiResponse.onSuccess(postService.createPost(treeId, request, token));
     }
 
     @GetMapping("/trees/{treeId}/feed")

--- a/src/main/java/org/example/tree/domain/post/converter/PostConverter.java
+++ b/src/main/java/org/example/tree/domain/post/converter/PostConverter.java
@@ -1,26 +1,21 @@
 package org.example.tree.domain.post.converter;
 
 import lombok.RequiredArgsConstructor;
-import org.example.tree.domain.post.dto.PostRequestDTO;
 import org.example.tree.domain.post.dto.PostResponseDTO;
 import org.example.tree.domain.post.entity.Post;
 import org.example.tree.domain.post.entity.PostImage;
 import org.example.tree.domain.profile.entity.Profile;
 import org.example.tree.domain.reaction.dto.ReactionResponseDTO;
 import org.example.tree.domain.tree.entity.Tree;
-import org.example.tree.global.common.amazons3.S3UploadService;
 import org.springframework.stereotype.Component;
-import org.springframework.web.multipart.MultipartFile;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Optional;
 import java.util.stream.Collectors;
 
 @Component
 @RequiredArgsConstructor
 public class PostConverter {
-    private final S3UploadService s3UploadService;
 
     public Post toPost(String content, Profile profile) {
         return Post.builder()
@@ -39,9 +34,6 @@ public class PostConverter {
                 .collect(Collectors.toList());
         return PostResponseDTO.createPost.builder()
                 .postId(savedPost.getId())
-                .postImageUrls(imageUrls)
-                .authorId(savedPost.getProfile().getMember().getId())
-                .treeId(savedPost.getTree().getId())
                 .build();
     }
 
@@ -72,13 +64,12 @@ public class PostConverter {
                 .build();
     }
 
-    public List<PostImage> toPostImages(List<MultipartFile> images) throws Exception {
+    public List<PostImage> toPostImages(List<String> images) throws Exception {
         List<PostImage> postImages = new ArrayList<>();
-        for(MultipartFile image :images) {
-            if (!image.isEmpty()) {
-                String postImageUrl = s3UploadService.uploadImage(image); // 이미지 업로드 후 URL 획득
+        for(String imageUrl :images) {
+            if (imageUrl != null) {// 이미지 업로드 후 URL 획득
                 PostImage postImage = PostImage.builder()
-                        .imageUrl(postImageUrl) // PostImage 엔티티에는 imageUrl 필드가 있어야 합니다.
+                        .imageUrl(imageUrl) // PostImage 엔티티에는 imageUrl 필드가 있어야 합니다.
                         .build();
                 postImages.add(postImage);
             }

--- a/src/main/java/org/example/tree/domain/post/dto/PostRequestDTO.java
+++ b/src/main/java/org/example/tree/domain/post/dto/PostRequestDTO.java
@@ -4,6 +4,8 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.util.List;
+
 
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 
@@ -12,6 +14,7 @@ public class PostRequestDTO {
     @Getter
     public static class createPost {
         private String content;
+        private List<String> images;
     }
 
     @Getter

--- a/src/main/java/org/example/tree/domain/post/dto/PostResponseDTO.java
+++ b/src/main/java/org/example/tree/domain/post/dto/PostResponseDTO.java
@@ -16,9 +16,6 @@ public class PostResponseDTO {
     @AllArgsConstructor
     public static class createPost {
         private Long postId;
-        private List<String> postImageUrls;
-        private String authorId;
-        private Long treeId;
     }
 
     @Builder

--- a/src/main/java/org/example/tree/domain/post/service/PostService.java
+++ b/src/main/java/org/example/tree/domain/post/service/PostService.java
@@ -36,9 +36,9 @@ public class PostService {
     private final BranchService branchService;
 
     @Transactional
-    public PostResponseDTO.createPost createPost(Long treeId, PostRequestDTO.createPost request, List<MultipartFile> images, String token) throws Exception {
+    public PostResponseDTO.createPost createPost(Long treeId, PostRequestDTO.createPost request, String token) throws Exception {
         Profile profile = profileService.getTreeProfile(token, treeId);
-        List<PostImage> postImages = postConverter.toPostImages(images);
+        List<PostImage> postImages = postConverter.toPostImages(request.getImages());
         Post post = postConverter.toPost(request.getContent(), profile);
         Post savedPost = postCommandService.createPost(post);
         for (PostImage postImage : postImages) {

--- a/src/main/java/org/example/tree/domain/profile/controller/ProfileController.java
+++ b/src/main/java/org/example/tree/domain/profile/controller/ProfileController.java
@@ -15,22 +15,20 @@ import org.springframework.web.multipart.MultipartFile;
 public class ProfileController {
     private final ProfileService profileService;
 
-    @PostMapping(value = "/trees/owner/register", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    @PostMapping("/trees/owner/register")
     @Operation(summary = "트리하우스 설립자 프로필 등록", description = "트리하우스 오너 프로필을 등록합니다.")
     public ApiResponse registerTreeOwner(
-            @RequestPart ProfileRequestDTO.ownerProfile request,
-            @RequestPart("profileImage") final MultipartFile profileImage
+            @RequestBody ProfileRequestDTO.ownerProfile request
     ) throws Exception {
-        return ApiResponse.onSuccess(profileService.ownerProfile(request, profileImage));
+        return ApiResponse.onSuccess(profileService.ownerProfile(request));
     }
 
-    @PostMapping(value = "/trees/members/register", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    @PostMapping("/trees/members/register")
     @Operation(summary = "트리하우스 멤버 프로필 등록", description = "트리하우스 멤버 프로필을 등록합니다.")
     public ApiResponse registerTreeMember(
-            @RequestPart ProfileRequestDTO.createProfile request,
-            @RequestPart("profileImage") final MultipartFile profileImage
+            @RequestBody ProfileRequestDTO.createProfile request
             ) throws Exception {
-        return ApiResponse.onSuccess(profileService.createProfile(request, profileImage));
+        return ApiResponse.onSuccess(profileService.createProfile(request));
     }
 
     @GetMapping("/trees/{treeId}/members/{profileId}") //프로필 조회

--- a/src/main/java/org/example/tree/domain/profile/dto/ProfileRequestDTO.java
+++ b/src/main/java/org/example/tree/domain/profile/dto/ProfileRequestDTO.java
@@ -12,7 +12,7 @@ public class ProfileRequestDTO {
         private Long treeId;
         private String userId;
         private String memberName;
-        private MultipartFile profileImage;
+        private String profileImage;
         private String bio;
 
     }
@@ -22,7 +22,7 @@ public class ProfileRequestDTO {
         private Long treeId;
         private String userId;
         private String memberName;
-        private MultipartFile profileImage;
+        private String profileImage;
         private String bio;
 
     }

--- a/src/main/java/org/example/tree/domain/profile/service/ProfileService.java
+++ b/src/main/java/org/example/tree/domain/profile/service/ProfileService.java
@@ -29,12 +29,11 @@ public class ProfileService {
     private final ProfileConverter profileConverter;
     private final TreeQueryService treeQueryService;
     private final MemberQueryService memberQueryService;
-    private final S3UploadService s3UploadService;
     private final BranchService branchService;
     private final InvitationQueryService invitationQueryService;
 
     @Transactional
-    public ProfileResponseDTO.createProfile createProfile(ProfileRequestDTO.createProfile request, MultipartFile profileImage) throws Exception {
+    public ProfileResponseDTO.createProfile createProfile(ProfileRequestDTO.createProfile request) throws Exception {
         Tree tree = treeQueryService.findById(request.getTreeId());
         Member member = memberQueryService.findById(request.getUserId());
         boolean isNewUser = profileQueryService.isNewUser(member);
@@ -43,7 +42,7 @@ public class ProfileService {
             currentProfile.inactivate();
             profileCommandService.updateProfile(currentProfile);
         }
-        String profileImageUrl = !profileImage.isEmpty() ? s3UploadService.uploadImage(profileImage) : DEFAULT_PROFILE_IMAGE;
+        String profileImageUrl = request.getProfileImage() == null ? DEFAULT_PROFILE_IMAGE : request.getProfileImage();
         Profile newProfile = profileConverter.toProfile(tree, member, request.getMemberName(), request.getBio(), profileImageUrl);
         profileCommandService.createProfile(newProfile);
         tree.increaseTreeSize();
@@ -54,7 +53,7 @@ public class ProfileService {
     }
 
     @Transactional
-    public ProfileResponseDTO.createProfile ownerProfile(ProfileRequestDTO.ownerProfile request, MultipartFile profileImage) throws Exception {
+    public ProfileResponseDTO.createProfile ownerProfile(ProfileRequestDTO.ownerProfile request) throws Exception {
         Tree tree = treeQueryService.findById(request.getTreeId());
         Member member = memberQueryService.findById(request.getUserId());
         boolean isNewUser = profileQueryService.isNewUser(member);
@@ -63,7 +62,7 @@ public class ProfileService {
             currentProfile.inactivate();
             profileCommandService.updateProfile(currentProfile);
         }
-        String profileImageUrl = !profileImage.isEmpty() ? s3UploadService.uploadImage(profileImage) : DEFAULT_PROFILE_IMAGE;
+        String profileImageUrl = request.getProfileImage() == null ? DEFAULT_PROFILE_IMAGE : request.getProfileImage();
         Profile newProfile = profileConverter.toProfile(tree, member, request.getMemberName(), request.getBio(), profileImageUrl);
         profileCommandService.createProfile(newProfile);
         tree.increaseTreeSize();


### PR DESCRIPTION
# 🚀 개요
<!-- 이 PR을 간략하게 설명해주세요 -->
기본 MultipartFile을 이용해 서버에서 이미지를 받아 S3에 업로드하고 URL을 반환하는 방식에서, 클라이언트가 직접 S3에 이미지를 업로드 하고 받은 Presigned URL을 서버에 전송해 저장하는 방식으로의 변경을 위한 리팩토링

## 🔍 변경사항
<!-- 이 PR로 인해 바뀌게 되는 것들을 목록으로 적어주세요. -->
- 트리하우스 가입 시, 프로필 이미지를 지정하는 방식의 변경
- 게시글 작성 시, 이미지를 하는 방식의 변경

## ⏳ 작업 내용
- [x] `ProfileController`, `PostController`의 create 관련 메서드 시그니처 변경
- [x] `ProfileService`, `PostService`의 create 관련 메서드 시그니처와 이미지 관련 로직 변경
- [x] `ProfileRequestDTO`, `PostRequestDTO`의 create 관련 클래스의 이미지 관련 필드를 String타입/List<String> 타입으로 변경

### 📝 논의사항
<!-- 이 PR에 대한 논의하고 싶은 사항이나, 더 해야할 작업, 리뷰어에게 특별히 확인 요청하고 싶은 부분 등을 적어주세요. -->

