### PR TITLE
Refactor/#87- ApiResponse와 DTO에 포함될 필드 이름과 형식 수정

### DIFF
--- a/src/main/java/org/example/tree/common/BaseDateTimeEntity.java
+++ b/src/main/java/org/example/tree/common/BaseDateTimeEntity.java
@@ -1,14 +1,13 @@
 package org.example.tree.common;
 
-import jakarta.persistence.Column;
-import jakarta.persistence.EntityListeners;
-import jakarta.persistence.MappedSuperclass;
+import jakarta.persistence.*;
 import lombok.Getter;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 
 @EntityListeners(AuditingEntityListener.class)
 @MappedSuperclass
@@ -16,8 +15,19 @@ import java.time.LocalDateTime;
 public abstract class BaseDateTimeEntity {
 
     @CreatedDate
-    private LocalDateTime createdAt;
+    private String createdAt;
 
     @LastModifiedDate
-    private LocalDateTime updatedAt;
+    private String updatedAt;
+
+    @PrePersist
+    public void prePersist() {
+        this.createdAt = LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyy.MM.dd"));
+        this.updatedAt = this.createdAt;
+    }
+
+    @PreUpdate
+    public void preUpdate() {
+        this.updatedAt = LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyy.MM.dd"));
+    }
 }

--- a/src/main/java/org/example/tree/domain/comment/dto/CommentResponseDTO.java
+++ b/src/main/java/org/example/tree/domain/comment/dto/CommentResponseDTO.java
@@ -20,7 +20,7 @@ public class CommentResponseDTO {
         private String authorName;
         private String content;
         private List<ReactionResponseDTO.getReaction> reactions;
-        private LocalDateTime createdAt;
+        private String createdAt;
         private List<ReplyResponseDTO.getReply> replies;
     }
 }

--- a/src/main/java/org/example/tree/domain/comment/dto/ReplyResponseDTO.java
+++ b/src/main/java/org/example/tree/domain/comment/dto/ReplyResponseDTO.java
@@ -19,6 +19,6 @@ public class ReplyResponseDTO {
         private String authorName;
         private String content;
         private List<ReactionResponseDTO.getReaction> reactions;
-        private LocalDateTime createdAt;
+        private String createdAt;
     }
 }

--- a/src/main/java/org/example/tree/domain/invitation/converter/InvitationConverter.java
+++ b/src/main/java/org/example/tree/domain/invitation/converter/InvitationConverter.java
@@ -30,14 +30,14 @@ public class InvitationConverter {
     public InvitationResponseDTO.acceptInvitation toAcceptInvitation (Invitation invitation) {
         return InvitationResponseDTO.acceptInvitation.builder()
                 .treeId(invitation.getTree().getId())
-                .isAccept(true)
+                .isAccepted(true)
                 .build();
     }
 
     public InvitationResponseDTO.rejectInvitation toRejectInvitation (Invitation invitation) {
         return InvitationResponseDTO.rejectInvitation.builder()
                 .treeId(invitation.getTree().getId())
-                .isAccept(false)
+                .isAccepted(false)
                 .build();
     }
 
@@ -53,8 +53,9 @@ public class InvitationConverter {
                 .invitationId(invitation.getId())
                 .treeName(invitation.getTree().getName())
                 .senderName(invitation.getSender().getMemberName())
-                .treeSize(invitation.getTree().getTreeSize())
-                .treeMemberProfileImages(treeMemberProfileImages)
+                .senderProfileImageUrl(invitation.getSender().getProfileImageUrl())
+                .treehouseSize(invitation.getTree().getTreeSize())
+                .treehouseMemberProfileImages(treeMemberProfileImages)
                 .build();
     }
 }

--- a/src/main/java/org/example/tree/domain/invitation/converter/InvitationConverter.java
+++ b/src/main/java/org/example/tree/domain/invitation/converter/InvitationConverter.java
@@ -51,7 +51,7 @@ public class InvitationConverter {
     public InvitationResponseDTO.getInvitation toGetInvitation (Invitation invitation, List<String> treeMemberProfileImages) {
         return InvitationResponseDTO.getInvitation.builder()
                 .invitationId(invitation.getId())
-                .treeName(invitation.getTree().getName())
+                .treehouseName(invitation.getTree().getName())
                 .senderName(invitation.getSender().getMemberName())
                 .senderProfileImageUrl(invitation.getSender().getProfileImageUrl())
                 .treehouseSize(invitation.getTree().getTreeSize())

--- a/src/main/java/org/example/tree/domain/invitation/dto/InvitationRequestDTO.java
+++ b/src/main/java/org/example/tree/domain/invitation/dto/InvitationRequestDTO.java
@@ -24,7 +24,7 @@ public class InvitationRequestDTO {
     @Getter
     public static class acceptInvitation {
         private Long invitationId;
-        private Boolean isAccept;
+        private Boolean isAccepted;
     }
 
     @Getter
@@ -35,6 +35,6 @@ public class InvitationRequestDTO {
     @Getter
     public static class rejectInvitation {
         private Long invitationId;
-        private Boolean isAccept;
+        private Boolean isAccepted;
     }
 }

--- a/src/main/java/org/example/tree/domain/invitation/dto/InvitationResponseDTO.java
+++ b/src/main/java/org/example/tree/domain/invitation/dto/InvitationResponseDTO.java
@@ -22,7 +22,7 @@ public class InvitationResponseDTO {
     @AllArgsConstructor
     public static class acceptInvitation {
         private Long treeId;
-        private Boolean isAccept;
+        private Boolean isAccepted;
     }
 
     @Builder
@@ -31,7 +31,7 @@ public class InvitationResponseDTO {
     @AllArgsConstructor
     public static class rejectInvitation {
         private Long treeId;
-        private Boolean isAccept;
+        private Boolean isAccepted;
     }
 
     @Builder
@@ -40,10 +40,11 @@ public class InvitationResponseDTO {
     @AllArgsConstructor
     public static class getInvitation {
         private Long invitationId;
-        private String treeName;
+        private String treehouseName;
         private String senderName;
-        private Integer treeSize;
-        private List<String> treeMemberProfileImages;
+        private String senderProfileImageUrl;
+        private Integer treehouseSize;
+        private List<String> treehouseMemberProfileImages;
     }
 
     @Builder

--- a/src/main/java/org/example/tree/domain/member/converter/MemberConverter.java
+++ b/src/main/java/org/example/tree/domain/member/converter/MemberConverter.java
@@ -39,9 +39,9 @@ public class MemberConverter {
                 .build();
     }
 
-    public MemberResponseDTO.checkId toCheckId(Boolean isDuplicate) {
+    public MemberResponseDTO.checkId toCheckId(Boolean isDuplicated) {
         return MemberResponseDTO.checkId.builder()
-                .isDuplicate(isDuplicate)
+                .isDuplicated(isDuplicated)
                 .build();
     }
 

--- a/src/main/java/org/example/tree/domain/member/dto/MemberResponseDTO.java
+++ b/src/main/java/org/example/tree/domain/member/dto/MemberResponseDTO.java
@@ -10,7 +10,7 @@ public class MemberResponseDTO {
     @NoArgsConstructor
     @AllArgsConstructor
     public static class checkId {
-        private Boolean isDuplicate;
+        private Boolean isDuplicated;
     }
 
     @Builder

--- a/src/main/java/org/example/tree/domain/member/service/MemberService.java
+++ b/src/main/java/org/example/tree/domain/member/service/MemberService.java
@@ -21,8 +21,8 @@ public class MemberService {
     @Transactional
     public MemberResponseDTO.checkId checkId(MemberRequestDTO.checkId request) {
         Optional<Member> optionalMember = memberQueryService.checkId(request.getUserId());
-        Boolean isDuplicate = optionalMember.isPresent();
-        return memberConverter.toCheckId(isDuplicate);
+        Boolean isDuplicated = optionalMember.isPresent();
+        return memberConverter.toCheckId(isDuplicated);
     }
     @Transactional
     public MemberResponseDTO.registerMember register(MemberRequestDTO.registerMember request) {

--- a/src/main/java/org/example/tree/domain/notification/dto/NotificationResponseDTO.java
+++ b/src/main/java/org/example/tree/domain/notification/dto/NotificationResponseDTO.java
@@ -19,6 +19,6 @@ public class NotificationResponseDTO {
         private String type;
         private Long treeId;
         private String treeName;
-        private LocalDateTime createdAt;
+        private String createdAt;
     }
 }

--- a/src/main/java/org/example/tree/domain/post/dto/PostResponseDTO.java
+++ b/src/main/java/org/example/tree/domain/post/dto/PostResponseDTO.java
@@ -43,7 +43,7 @@ public class PostResponseDTO {
         private List<String> postImageUrls;
         private List<ReactionResponseDTO.getReaction> reactions;
         private Integer commentCount;
-        private LocalDateTime createdAt;
+        private String createdAt;
 
     }
 

--- a/src/main/java/org/example/tree/global/common/ApiResponse.java
+++ b/src/main/java/org/example/tree/global/common/ApiResponse.java
@@ -1,5 +1,6 @@
 package org.example.tree.global.common;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
@@ -38,6 +39,8 @@ public class ApiResponse<T> {
     private String code;
     @JsonProperty("message")
     private String message;
+
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy.MM.dd")
     @JsonProperty("createdAt")
     private LocalDateTime createdAt;
     @JsonProperty("data")


### PR DESCRIPTION
# 🚀 개요
<!-- 이 PR을 간략하게 설명해주세요 -->
2024.04.04 회의 내용을 기반으로 API 응답에 포함될 필드들의 형식과 이름을 수정합니다.

## 🔍 변경사항
<!-- 이 PR로 인해 바뀌게 되는 것들을 목록으로 적어주세요. -->
- 특정 객체의 상태를 나타내는 Boolean 값들의 이름을 과거분사형으로 수정 ex) `isDuplicate` -> `isDuplicated`
- 날짜 정보가 들어간 필드의 형식을 yyyy.MM.dd 로 수정


## ⏳ 작업 내용
- [x] 특정 객체의 상태를 나타내는 Boolean 값들의 이름을 과거분사형으로 수정 ex) `isDuplicate` -> `isDuplicated`
- [x] 날짜 정보가 들어간 필드의 형식을 yyyy.MM.dd 로 수정
- [x] `BaseDateTimeEntity` 에서도 `@PrePersist` 와 `@PreUpdate`를 이용해 날짜 형식 지정

### 📝 논의사항
<!-- 이 PR에 대한 논의하고 싶은 사항이나, 더 해야할 작업, 리뷰어에게 특별히 확인 요청하고 싶은 부분 등을 적어주세요. -->

