### PR TITLE
[REFACTOR]/#88- Member 엔티티의 필드를 변경하여 id와 userName으로 관리하기

### DIFF
--- a/src/main/java/org/example/tree/domain/invitation/dto/InvitationRequestDTO.java
+++ b/src/main/java/org/example/tree/domain/invitation/dto/InvitationRequestDTO.java
@@ -9,16 +9,16 @@ public class InvitationRequestDTO {
 
     @Getter
     public static class sendInvitation {
-        private String senderId;
+        private Long senderId;
         private Long treeId;
         private String phoneNumber;
     }
 
     @Getter
     public static class inviteMember {
-        private String senderId;
+        private Long senderId;
         private Long treeId;
-        private String targetUserId;
+        private Long targetUserId;
     }
 
     @Getter

--- a/src/main/java/org/example/tree/domain/member/controller/MemberController.java
+++ b/src/main/java/org/example/tree/domain/member/controller/MemberController.java
@@ -15,10 +15,10 @@ public class MemberController {
     private final MemberService memberService;
     @PostMapping("/checkId")
     @Operation(summary = "아이디 중복 체크", description = "서비스에서 사용할 고유 ID를 중복 체크합니다.")
-    public ApiResponse<MemberResponseDTO.checkId> checkId(
+    public ApiResponse<MemberResponseDTO.checkName> checkName(
             @RequestBody final MemberRequestDTO.checkName request
     ) {
-        return ApiResponse.onSuccess(memberService.checkId(request));
+        return ApiResponse.onSuccess(memberService.checkName(request));
     }
     @PostMapping("/register")
     @Operation(summary = "회원가입", description = "회원가입을 진행합니다.")

--- a/src/main/java/org/example/tree/domain/member/controller/MemberController.java
+++ b/src/main/java/org/example/tree/domain/member/controller/MemberController.java
@@ -16,7 +16,7 @@ public class MemberController {
     @PostMapping("/checkId")
     @Operation(summary = "아이디 중복 체크", description = "서비스에서 사용할 고유 ID를 중복 체크합니다.")
     public ApiResponse<MemberResponseDTO.checkId> checkId(
-            @RequestBody final MemberRequestDTO.checkId request
+            @RequestBody final MemberRequestDTO.checkName request
     ) {
         return ApiResponse.onSuccess(memberService.checkId(request));
     }

--- a/src/main/java/org/example/tree/domain/member/converter/MemberConverter.java
+++ b/src/main/java/org/example/tree/domain/member/converter/MemberConverter.java
@@ -40,8 +40,8 @@ public class MemberConverter {
                 .build();
     }
 
-    public MemberResponseDTO.checkId toCheckName(Boolean isDuplicate) {
-        return MemberResponseDTO.checkId.builder()
+    public MemberResponseDTO.checkName toCheckName(Boolean isDuplicate) {
+        return MemberResponseDTO.checkName.builder()
                 .isDuplicate(isDuplicate)
                 .build();
     }

--- a/src/main/java/org/example/tree/domain/member/converter/MemberConverter.java
+++ b/src/main/java/org/example/tree/domain/member/converter/MemberConverter.java
@@ -5,8 +5,8 @@ import lombok.RequiredArgsConstructor;
 import org.example.tree.domain.member.dto.MemberResponseDTO;
 import org.example.tree.domain.member.entity.Member;
 import org.example.tree.domain.member.entity.MemberRole;
+import org.example.tree.domain.member.entity.MemberStatus;
 import org.example.tree.domain.member.service.MemberQueryService;
-import org.example.tree.domain.member.service.MemberService;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -28,25 +28,27 @@ public class MemberConverter {
      * @return Member
      */
     public static Member toMemberSecurity(String id){
-        return staticMemberQueryService.findById(id);
+        return staticMemberQueryService.findById(Long.valueOf(id));
     }
 
-    public Member toMember (String id, String phone) {
+    public Member toMember (String userName, String phone) {
         return Member.builder()
-                .id(id)
+                .userName(userName)
                 .phone(phone)
                 .role(MemberRole.ROLE_USER)
+                .status(MemberStatus.ACTIVE)
                 .build();
     }
 
-    public MemberResponseDTO.checkId toCheckId(Boolean isDuplicate) {
+    public MemberResponseDTO.checkId toCheckName(Boolean isDuplicate) {
         return MemberResponseDTO.checkId.builder()
                 .isDuplicate(isDuplicate)
                 .build();
     }
 
-    public MemberResponseDTO.registerMember toRegister(String accessToken, String refreshToken) {
+    public MemberResponseDTO.registerMember toRegister(Member member, String accessToken, String refreshToken) {
         return MemberResponseDTO.registerMember.builder()
+                .userId(member.getId())
                 .accessToken(accessToken)
                 .refreshToken(refreshToken)
                 .build();

--- a/src/main/java/org/example/tree/domain/member/converter/MemberConverter.java
+++ b/src/main/java/org/example/tree/domain/member/converter/MemberConverter.java
@@ -40,8 +40,8 @@ public class MemberConverter {
                 .build();
     }
 
-    public MemberResponseDTO.checkId toCheckId(Boolean isDuplicated) {
-        return MemberResponseDTO.checkId.builder()
+    public MemberResponseDTO.checkId toCheckName(Boolean isDuplicated) {
+        return MemberResponseDTO.checkName.builder()
                 .isDuplicated(isDuplicated)
                 .build();
     }

--- a/src/main/java/org/example/tree/domain/member/dto/MemberRequestDTO.java
+++ b/src/main/java/org/example/tree/domain/member/dto/MemberRequestDTO.java
@@ -8,14 +8,14 @@ import lombok.NoArgsConstructor;
 public class MemberRequestDTO {
 
     @Getter
-    public static class checkId {
-        private String userId;
+    public static class checkName {
+        private String userName;
     }
 
     @Getter
     public static class registerMember {
         private String phoneNumber;
-        private String userId;
+        private String userName;
     }
 
     @Getter

--- a/src/main/java/org/example/tree/domain/member/dto/MemberResponseDTO.java
+++ b/src/main/java/org/example/tree/domain/member/dto/MemberResponseDTO.java
@@ -18,6 +18,7 @@ public class MemberResponseDTO {
     @NoArgsConstructor
     @AllArgsConstructor
     public static class registerMember {
+        private Long userId;
         private String accessToken;
         private String refreshToken;
     }

--- a/src/main/java/org/example/tree/domain/member/dto/MemberResponseDTO.java
+++ b/src/main/java/org/example/tree/domain/member/dto/MemberResponseDTO.java
@@ -9,7 +9,7 @@ public class MemberResponseDTO {
     @Getter
     @NoArgsConstructor
     @AllArgsConstructor
-    public static class checkId {
+    public static class checkName {
         private Boolean isDuplicate;
     }
 

--- a/src/main/java/org/example/tree/domain/member/dto/MemberResponseDTO.java
+++ b/src/main/java/org/example/tree/domain/member/dto/MemberResponseDTO.java
@@ -9,7 +9,7 @@ public class MemberResponseDTO {
     @Getter
     @NoArgsConstructor
     @AllArgsConstructor
-    public static class checkId {
+    public static class checkName {
         private Boolean isDuplicated;
     }
 

--- a/src/main/java/org/example/tree/domain/member/entity/Member.java
+++ b/src/main/java/org/example/tree/domain/member/entity/Member.java
@@ -3,10 +3,8 @@ package org.example.tree.domain.member.entity;
 import jakarta.persistence.*;
 import lombok.*;
 import org.example.tree.common.BaseDateTimeEntity;
-import org.example.tree.domain.post.entity.Post;
 
 import java.time.LocalDateTime;
-import java.util.List;
 
 @Entity
 @Getter
@@ -17,7 +15,10 @@ import java.util.List;
 public class Member extends BaseDateTimeEntity {
 
     @Id
-    private String id; //고유 문자열 아이디(인스타그램 st.)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String userName; //고유 문자열 아이디(인스타그램 st.)
 
     private String bio;
 

--- a/src/main/java/org/example/tree/domain/member/repository/MemberRepository.java
+++ b/src/main/java/org/example/tree/domain/member/repository/MemberRepository.java
@@ -7,4 +7,7 @@ import java.util.Optional;
 
 public interface MemberRepository extends JpaRepository<Member, String> {
     Optional<Member> findByPhone(String phone);
+
+    Optional<Member> findByUserName(String userName);
+
 }

--- a/src/main/java/org/example/tree/domain/member/repository/RefreshTokenRepository.java
+++ b/src/main/java/org/example/tree/domain/member/repository/RefreshTokenRepository.java
@@ -8,5 +8,5 @@ import java.util.Optional;
 
 @Repository
 public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long> {
-    Optional<RefreshToken> findByMemberId(String memberId);
+    Optional<RefreshToken> findByMemberId(Long memberId);
 }

--- a/src/main/java/org/example/tree/domain/member/service/MemberCommandService.java
+++ b/src/main/java/org/example/tree/domain/member/service/MemberCommandService.java
@@ -38,8 +38,8 @@ public class MemberCommandService {
     }
     public TokenDTO login(Member member) {
 
-        String accessToken = tokenProvider.createAccessToken(member.getId(), List.of(new SimpleGrantedAuthority(MemberRole.ROLE_USER.name())));
-        String rawToken = tokenProvider.createRefreshToken(member.getId());
+        String accessToken = tokenProvider.createAccessToken(String.valueOf(member.getId()), List.of(new SimpleGrantedAuthority(MemberRole.ROLE_USER.name())));
+        String rawToken = tokenProvider.createRefreshToken(String.valueOf(member.getId()));
         RefreshToken refreshToken = RefreshToken.builder()
                 .memberId(member.getId())
                 .token(rawToken)
@@ -55,8 +55,8 @@ public class MemberCommandService {
         RefreshToken invalidToken = refreshTokenRepository.findByMemberId(member.getId())
                 .orElseThrow(() -> new GeneralException(GlobalErrorCode.REFRESH_TOKEN_NOT_FOUND));
         refreshTokenRepository.delete(invalidToken);
-        String accessToken = tokenProvider.createAccessToken(member.getId(),List.of(new SimpleGrantedAuthority(MemberRole.ROLE_USER.name())));
-        String rawToken = tokenProvider.createRefreshToken(member.getId());
+        String accessToken = tokenProvider.createAccessToken(String.valueOf(member.getId()),List.of(new SimpleGrantedAuthority(MemberRole.ROLE_USER.name())));
+        String rawToken = tokenProvider.createRefreshToken(String.valueOf(member.getId()));
         RefreshToken refreshToken = RefreshToken.builder()
                 .memberId(member.getId())
                 .token(rawToken)

--- a/src/main/java/org/example/tree/domain/member/service/MemberQueryService.java
+++ b/src/main/java/org/example/tree/domain/member/service/MemberQueryService.java
@@ -16,11 +16,11 @@ public class MemberQueryService {
     private final MemberRepository memberRepository;
     private final TokenProvider jwtTokenProvider;
 
-    public Optional<Member> checkId(String id) {
-        return memberRepository.findById(id);
+    public Optional<Member> checkName(String userName) {
+        return memberRepository.findByUserName(userName);
     }
-    public Member findById(String id) {
-        return memberRepository.findById(id)
+    public Member findById(Long id) {
+        return memberRepository.findById(String.valueOf(id))
                 .orElseThrow(()->new GeneralException(GlobalErrorCode.MEMBER_NOT_FOUND));
     }
 

--- a/src/main/java/org/example/tree/domain/member/service/MemberService.java
+++ b/src/main/java/org/example/tree/domain/member/service/MemberService.java
@@ -19,7 +19,7 @@ public class MemberService {
     private final MemberConverter memberConverter;
 
     @Transactional
-    public MemberResponseDTO.checkId checkId(MemberRequestDTO.checkName request) {
+    public MemberResponseDTO.checkName checkName(MemberRequestDTO.checkName request) {
         Optional<Member> optionalMember = memberQueryService.checkName(request.getUserName());
         Boolean isDuplicate = optionalMember.isPresent();
         return memberConverter.toCheckName(isDuplicate);

--- a/src/main/java/org/example/tree/domain/member/service/MemberService.java
+++ b/src/main/java/org/example/tree/domain/member/service/MemberService.java
@@ -19,17 +19,17 @@ public class MemberService {
     private final MemberConverter memberConverter;
 
     @Transactional
-    public MemberResponseDTO.checkId checkId(MemberRequestDTO.checkId request) {
-        Optional<Member> optionalMember = memberQueryService.checkId(request.getUserId());
+    public MemberResponseDTO.checkId checkId(MemberRequestDTO.checkName request) {
+        Optional<Member> optionalMember = memberQueryService.checkName(request.getUserName());
         Boolean isDuplicate = optionalMember.isPresent();
-        return memberConverter.toCheckId(isDuplicate);
+        return memberConverter.toCheckName(isDuplicate);
     }
     @Transactional
     public MemberResponseDTO.registerMember register(MemberRequestDTO.registerMember request) {
-        Member member = memberConverter.toMember(request.getUserId(), request.getPhoneNumber());
+        Member member = memberConverter.toMember(request.getUserName(), request.getPhoneNumber());
         Member savedMember =memberCommandService.register(member);
         TokenDTO savedToken = memberCommandService.login(savedMember);
-        return memberConverter.toRegister(savedToken.getAccessToken(), savedToken.getRefreshToken());
+        return memberConverter.toRegister(savedMember, savedToken.getAccessToken(), savedToken.getRefreshToken());
     }
 
     @Transactional

--- a/src/main/java/org/example/tree/domain/notification/dto/NotificationRequestDTO.java
+++ b/src/main/java/org/example/tree/domain/notification/dto/NotificationRequestDTO.java
@@ -14,6 +14,6 @@ public class NotificationRequestDTO {
         private String title;
         private String message;
         private NotificationType type;
-        private String receiverId;
+        private Long receiverId;
     }
 }

--- a/src/main/java/org/example/tree/domain/notification/service/NotificationService.java
+++ b/src/main/java/org/example/tree/domain/notification/service/NotificationService.java
@@ -28,28 +28,28 @@ public class NotificationService {
     private final MemberQueryService memberQueryService;
 
     @Transactional
-    public void sendNotification(String title, String message, NotificationType type, String receiverId) {
+    public void sendNotification(String title, String message, NotificationType type, Long receiverId) {
         Member receiver = memberQueryService.findById(receiverId);
         Notification notification = notificationConverter.toNotification(title, message, type, receiver);
         notificationCommandService.createNotification(notification);
     }
 
     @Transactional
-    public void commentNotification(Profile sender, Comment comment, String receiverId) {
+    public void commentNotification(Profile sender, Comment comment, Long receiverId) {
         Member receiver = memberQueryService.findById(receiverId);
         Notification notification = notificationConverter.toCommentNotification(sender, comment, receiver);
         notificationCommandService.createNotification(notification);
     }
 
     @Transactional
-    public void reactionNotification(Profile sender, Reaction reaction, String receiverId) {
+    public void reactionNotification(Profile sender, Reaction reaction, Long receiverId) {
         Member receiver = memberQueryService.findById(receiverId);
         Notification notification = notificationConverter.toReactionNotification(sender, reaction, receiver);
         notificationCommandService.createNotification(notification);
     }
 
     @Transactional
-    public void invitationNotification(Profile sender, Invitation invitation, String receiverId) {
+    public void invitationNotification(Profile sender, Invitation invitation, Long receiverId) {
         Member receiver = memberQueryService.findById(receiverId);
         Notification notification = notificationConverter.toInvitationNotification(sender, invitation, receiver);
         notificationCommandService.createNotification(notification);

--- a/src/main/java/org/example/tree/domain/profile/dto/ProfileRequestDTO.java
+++ b/src/main/java/org/example/tree/domain/profile/dto/ProfileRequestDTO.java
@@ -10,7 +10,7 @@ public class ProfileRequestDTO {
     @Getter
     public static class createProfile {
         private Long treeId;
-        private String userId;
+        private Long userId;
         private String memberName;
         private String profileImage;
         private String bio;
@@ -20,7 +20,7 @@ public class ProfileRequestDTO {
     @Getter
     public static class ownerProfile {
         private Long treeId;
-        private String userId;
+        private Long userId;
         private String memberName;
         private String profileImage;
         private String bio;

--- a/src/main/java/org/example/tree/domain/profile/dto/ProfileResponseDTO.java
+++ b/src/main/java/org/example/tree/domain/profile/dto/ProfileResponseDTO.java
@@ -25,7 +25,7 @@ public class ProfileResponseDTO {
     public static class getProfileDetails {
         private Long profileId;
         private List<Long> treeIds;
-        private String memberId;
+        private Long memberId;
         private String memberName;
         private String bio;
         private String profileImageUrl;

--- a/src/main/java/org/example/tree/domain/profile/repository/ProfileRepository.java
+++ b/src/main/java/org/example/tree/domain/profile/repository/ProfileRepository.java
@@ -16,7 +16,7 @@ public interface ProfileRepository extends JpaRepository<Profile, Long> {
     Optional<Profile> findByMemberAndTree(Member member, Tree tree);
 
 
-    List<Profile> findAllByMember_Id(String memberId);
+    List<Profile> findAllByMember_Id(Long memberId);
 
     List<Profile> findAllByTree(Tree tree);
 

--- a/src/main/java/org/example/tree/domain/profile/service/ProfileQueryService.java
+++ b/src/main/java/org/example/tree/domain/profile/service/ProfileQueryService.java
@@ -27,7 +27,7 @@ public class ProfileQueryService {
     }
 
     public List<Long> findJoinedTree(Profile profile) {
-        String memberId = profile.getMember().getId();
+        Long memberId = profile.getMember().getId();
         List<Profile> foundProfiles = profileRepository.findAllByMember_Id(memberId);
         return foundProfiles.stream()
                 .map(foundProfile -> foundProfile.getTree().getId())

--- a/src/main/java/org/example/tree/global/security/jwt/RefreshToken.java
+++ b/src/main/java/org/example/tree/global/security/jwt/RefreshToken.java
@@ -11,7 +11,7 @@ import lombok.*;
 @Getter
 public class RefreshToken {
     @Id
-    private String memberId;
+    private Long memberId;
 
     private String token;
 }

--- a/src/main/java/org/example/tree/global/security/provider/TokenProvider.java
+++ b/src/main/java/org/example/tree/global/security/provider/TokenProvider.java
@@ -125,7 +125,7 @@ public class TokenProvider {
 
         // 저장된 토큰과 비교
         String memberId = getMemberIdFromToken(refreshToken);
-        Optional<RefreshToken> refreshTokenOptional = refreshTokenRepository.findByMemberId(memberId);
+        Optional<RefreshToken> refreshTokenOptional = refreshTokenRepository.findByMemberId(Long.valueOf(memberId));
 
         if (!refreshTokenOptional.isPresent()) {
             log.warn("No matching refresh token found for email: {}", memberId);


### PR DESCRIPTION
# 🚀 개요
<!-- 이 PR을 간략하게 설명해주세요 -->
기존의 String 타입의 id로 Member를 관리하던 방식에서(인스타그램 느낌)
DB에 저장할 Long 타입의 고유 id 값 + String 타입의 고유 userName값으로 분리하는 작업을 진행했습니다.

## 🔍 변경사항
<!-- 이 PR로 인해 바뀌게 되는 것들을 목록으로 적어주세요. -->
- checkId 대신 checkName로 메서드명 변경
- Member 엔티티 - id + userName 필드 구조로 변경
- 다른 비즈니스 로직에서 Member의 id를 사용하는 부분 Long 타입으로 형변환

## ⏳ 작업 내용
- [x] checkId 대신 checkName로 메서드명 변경
- [x] Member 엔티티 - id + userName 필드 구조로 변경
- [x] 다른 비즈니스 로직에서 Member의 id를 사용하는 부분 Long 타입으로 형변환

### 📝 논의사항
<!-- 이 PR에 대한 논의하고 싶은 사항이나, 더 해야할 작업, 리뷰어에게 특별히 확인 요청하고 싶은 부분 등을 적어주세요. -->
Spring Security와 JWT 토큰 관련해서 memberId가 Long 타입으로 바뀐 것이 문제를 일으키진 않을지 궁금합니다!
(우선은 createAccessToken이나 toMemberSecurity에는 String.valueOf와 Long.valueOf을 이용해 넘겨주도록 수정했습니다.)