### PR TITLE
[REFACTOR]/#86 - Exception 구조 변경

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -37,7 +37,7 @@ dependencies {
     runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
     runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
 
-    // reids
+    // redis
     implementation 'org.springframework.boot:spring-boot-starter-data-redis:2.3.1.RELEASE'
 
     // lombok
@@ -55,6 +55,9 @@ dependencies {
 
     // jackson
     implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.9.8'
+
+    // validation
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
 
     runtimeOnly 'com.h2database:h2'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'

--- a/src/main/java/org/example/tree/domain/comment/service/CommentService.java
+++ b/src/main/java/org/example/tree/domain/comment/service/CommentService.java
@@ -16,6 +16,8 @@ import org.example.tree.domain.profile.entity.Profile;
 import org.example.tree.domain.profile.service.ProfileService;
 import org.example.tree.domain.reaction.dto.ReactionResponseDTO;
 import org.example.tree.domain.reaction.service.ReactionService;
+import org.example.tree.global.exception.AuthErrorCode;
+import org.example.tree.global.exception.AuthException;
 import org.example.tree.global.exception.GeneralException;
 import org.example.tree.global.exception.GlobalErrorCode;
 import org.springframework.stereotype.Component;
@@ -66,7 +68,7 @@ public class CommentService {
         Post post = postQueryService.findById(postId);
         Comment comment = commentQueryService.findById(commentId);
         if (!comment.getProfile().getId().equals(profile.getId())) {
-            throw new GeneralException(GlobalErrorCode.AUTHENTICATION_REQUIRED);
+            throw new AuthException(AuthErrorCode.AUTHENTICATION_REQUIRED);
         }
         comment.updateComment(request.getContent());
     }
@@ -77,7 +79,7 @@ public class CommentService {
         Post post = postQueryService.findById(postId);
         Comment comment = commentQueryService.findById(commentId);
         if (!comment.getProfile().getId().equals(profile.getId())) {
-            throw new GeneralException(GlobalErrorCode.AUTHENTICATION_REQUIRED);
+            throw new AuthException(AuthErrorCode.AUTHENTICATION_REQUIRED);
         }
         post.decreaseCommentCount();
         commentCommandService.deleteComment(comment);

--- a/src/main/java/org/example/tree/domain/comment/service/ReplyService.java
+++ b/src/main/java/org/example/tree/domain/comment/service/ReplyService.java
@@ -12,6 +12,8 @@ import org.example.tree.domain.profile.entity.Profile;
 import org.example.tree.domain.profile.service.ProfileService;
 import org.example.tree.domain.reaction.dto.ReactionResponseDTO;
 import org.example.tree.domain.reaction.service.ReactionService;
+import org.example.tree.global.exception.AuthErrorCode;
+import org.example.tree.global.exception.AuthException;
 import org.example.tree.global.exception.GeneralException;
 import org.example.tree.global.exception.GlobalErrorCode;
 import org.springframework.stereotype.Component;
@@ -54,7 +56,7 @@ public class ReplyService {
         Comment comment = commentQueryService.findById(commentId);
         Reply reply = replyQueryService.findById(replyId);
         if (!reply.getProfile().getId().equals(profile.getId())) {
-            throw new GeneralException(GlobalErrorCode.AUTHENTICATION_REQUIRED);
+            throw new AuthException(AuthErrorCode.AUTHENTICATION_REQUIRED);
         }
         reply.updateReply(request.getContent());
     }
@@ -65,7 +67,7 @@ public class ReplyService {
         Comment comment = commentQueryService.findById(commentId);
         Reply reply = replyQueryService.findById(replyId);
         if (!reply.getProfile().getId().equals(profile.getId())) {
-            throw new GeneralException(GlobalErrorCode.AUTHENTICATION_REQUIRED);
+            throw new AuthException(AuthErrorCode.AUTHENTICATION_REQUIRED);
         }
         replyCommandService.deleteReply(reply);
     }

--- a/src/main/java/org/example/tree/domain/member/service/MemberService.java
+++ b/src/main/java/org/example/tree/domain/member/service/MemberService.java
@@ -7,6 +7,8 @@ import org.example.tree.domain.member.dto.MemberRequestDTO;
 import org.example.tree.domain.member.dto.MemberResponseDTO;
 import org.example.tree.domain.member.entity.Member;
 import org.example.tree.domain.member.entity.redis.RefreshToken;
+import org.example.tree.global.exception.AuthErrorCode;
+import org.example.tree.global.exception.AuthException;
 import org.example.tree.global.exception.GeneralException;
 import org.example.tree.global.exception.GlobalErrorCode;
 import org.example.tree.global.redis.service.RedisService;
@@ -47,7 +49,7 @@ public class MemberService {
 
     @Transactional
     public MemberResponseDTO.reissue reissue(MemberRequestDTO.reissue request) {
-        RefreshToken refreshToken = redisService.findRefreshToken(request.getRefreshToken()).orElseThrow(() -> new GeneralException(GlobalErrorCode.REFRESH_TOKEN_EXPIRED));
+        RefreshToken refreshToken = redisService.findRefreshToken(request.getRefreshToken()).orElseThrow(() -> new AuthException(AuthErrorCode.REFRESH_TOKEN_EXPIRED));
         Member member = memberQueryService.findById(refreshToken.getMemberId());
         TokenDTO token = memberCommandService.reissueToken(member,refreshToken);
         return memberConverter.toReissue(token.getAccessToken(), token.getRefreshToken());

--- a/src/main/java/org/example/tree/domain/post/service/PostService.java
+++ b/src/main/java/org/example/tree/domain/post/service/PostService.java
@@ -15,6 +15,8 @@ import org.example.tree.domain.profile.service.ProfileQueryService;
 import org.example.tree.domain.profile.service.ProfileService;
 import org.example.tree.domain.reaction.dto.ReactionResponseDTO;
 import org.example.tree.domain.reaction.service.ReactionService;
+import org.example.tree.global.exception.AuthErrorCode;
+import org.example.tree.global.exception.AuthException;
 import org.example.tree.global.exception.GeneralException;
 import org.example.tree.global.exception.GlobalErrorCode;
 import org.springframework.stereotype.Component;
@@ -93,7 +95,7 @@ public class PostService {
         Profile profile = profileService.getTreeProfile(member, treeId);
         Post post = postQueryService.findById(postId);
         if (!post.getProfile().getId().equals(profile.getId())) {
-            throw new GeneralException(GlobalErrorCode.AUTHENTICATION_REQUIRED);
+            throw new AuthException(AuthErrorCode.AUTHENTICATION_REQUIRED);
         }
         post.updatePost(request.getContent());
     }
@@ -103,7 +105,7 @@ public class PostService {
         Profile profile = profileService.getTreeProfile(member, treeId);
         Post post = postQueryService.findById(postId);
         if (!post.getProfile().getId().equals(profile.getId())) {
-            throw new GeneralException(GlobalErrorCode.AUTHENTICATION_REQUIRED);
+            throw new AuthException(AuthErrorCode.AUTHENTICATION_REQUIRED);
         }
         postCommandService.deletePost(post);
     }

--- a/src/main/java/org/example/tree/domain/tree/service/TreeQueryService.java
+++ b/src/main/java/org/example/tree/domain/tree/service/TreeQueryService.java
@@ -17,7 +17,7 @@ public class TreeQueryService {
 
     public Tree findById(Long id) {
         return treeRepository.findById(id)
-                .orElseThrow(()->new GeneralException(GlobalErrorCode.TREE_NOT_FOUND));
+                .orElseThrow(()->new GeneralException(GlobalErrorCode.TREEHOUSE_NOT_FOUND));
     }
 
 }

--- a/src/main/java/org/example/tree/global/common/ApiResponse.java
+++ b/src/main/java/org/example/tree/global/common/ApiResponse.java
@@ -53,8 +53,8 @@ public class ApiResponse<T> {
     }
 
     // 실패한 경우 응답 생성
-    public static <T> ApiResponse<T> onFailure(GlobalErrorCode code, T data){
-        return new ApiResponse<>(false, String.valueOf(code.getHttpStatus().value()), code.getMessage(), LocalDateTime.now(), data);
+    public static <T> ApiResponse<T> onFailure(String code, String message, T data){
+        return new ApiResponse<>(false,code, message, LocalDateTime.now(), data);
     }
 
 }

--- a/src/main/java/org/example/tree/global/exception/AuthErrorCode.java
+++ b/src/main/java/org/example/tree/global/exception/AuthErrorCode.java
@@ -1,0 +1,49 @@
+package org.example.tree.global.exception;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+import static org.springframework.http.HttpStatus.*;
+
+@Getter
+@AllArgsConstructor
+public enum AuthErrorCode implements BaseErrorCode{
+    // 401 Unauthorized - 권한 없음
+    TOKEN_EXPIRED(UNAUTHORIZED, "AUTH401_1", "인증 토큰이 만료 되었습니다. 토큰을 재발급 해주세요"),
+    INVALID_TOKEN(UNAUTHORIZED, "AUTH401_2", "인증 토큰이 유효하지 않습니다."),
+    INVALID_REFRESH_TOKEN(UNAUTHORIZED, "AUTH401_3", "리프레시 토큰이 유효하지 않습니다."),
+    REFRESH_TOKEN_EXPIRED(UNAUTHORIZED, "AUTH401_4", "리프레시 토큰이 만료 되었습니다."),
+    AUTHENTICATION_REQUIRED(UNAUTHORIZED, "AUTH401_5", "인증 정보가 유효하지 않습니다."),
+    LOGIN_REQUIRED(UNAUTHORIZED, "AUTH401_6", "로그인이 필요한 서비스입니다."),
+
+    // 403 Forbidden - 인증 거부
+    AUTHENTICATION_DENIED(FORBIDDEN, "AUTH403_1", "인증이 거부 되었습니다."),
+
+    // 404 Not Found - 찾을 수 없음
+    REFRESH_TOKEN_NOT_FOUND(NOT_FOUND, "AUTH404_1", "리프레시 토큰이 존재하지 않습니다."),
+    ;
+
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+
+    @Override
+    public ErrorReasonDTO getReason() {
+        return ErrorReasonDTO.builder()
+                .message(message)
+                .code(code)
+                .isSuccess(false)
+                .build();
+    }
+
+    @Override
+    public ErrorReasonDTO getReasonHttpStatus() {
+        return ErrorReasonDTO.builder()
+                .message(message)
+                .code(code)
+                .httpStatus(httpStatus)
+                .isSuccess(false)
+                .build();
+    }
+}

--- a/src/main/java/org/example/tree/global/exception/AuthException.java
+++ b/src/main/java/org/example/tree/global/exception/AuthException.java
@@ -1,0 +1,8 @@
+package org.example.tree.global.exception;
+
+public class AuthException extends GeneralException{
+
+    public AuthException(BaseErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/org/example/tree/global/exception/BaseErrorCode.java
+++ b/src/main/java/org/example/tree/global/exception/BaseErrorCode.java
@@ -1,0 +1,8 @@
+package org.example.tree.global.exception;
+
+public interface BaseErrorCode {
+
+    public ErrorReasonDTO getReason();
+
+    public ErrorReasonDTO getReasonHttpStatus();
+}

--- a/src/main/java/org/example/tree/global/exception/ErrorReasonDTO.java
+++ b/src/main/java/org/example/tree/global/exception/ErrorReasonDTO.java
@@ -1,0 +1,16 @@
+package org.example.tree.global.exception;
+
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@Builder
+public class ErrorReasonDTO {
+
+    private HttpStatus httpStatus;
+
+    private final boolean isSuccess;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/org/example/tree/global/exception/GeneralException.java
+++ b/src/main/java/org/example/tree/global/exception/GeneralException.java
@@ -6,5 +6,14 @@ import lombok.Getter;
 @Getter
 @AllArgsConstructor
 public class GeneralException extends RuntimeException {
-private final GlobalErrorCode errorCode;
+
+    private final BaseErrorCode errorCode;
+
+    public ErrorReasonDTO getErrorReason() {
+        return this.errorCode.getReason();
+    }
+
+    public ErrorReasonDTO getErrorReasonHttpStatus() {
+        return this.errorCode.getReasonHttpStatus();
+    }
 }

--- a/src/main/java/org/example/tree/global/exception/GeneralExceptionHandler.java
+++ b/src/main/java/org/example/tree/global/exception/GeneralExceptionHandler.java
@@ -96,21 +96,22 @@ public class GeneralExceptionHandler extends ResponseEntityExceptionHandler {
             GeneralException generalException,
             @AuthenticationPrincipal User user,
             HttpServletRequest request) {
-        getExceptionStackTrace(generalException, user, request);
-        GlobalErrorCode errorCode = generalException.getErrorCode();
-        return handleExceptionInternal(generalException, errorCode, null, request);
+//        getExceptionStackTrace(generalException, user, request);
+//        GlobalErrorCode errorCode = generalException.getErrorCode();
+        ErrorReasonDTO errorReasonHttpStatus = generalException.getErrorReasonHttpStatus();
+        return handleExceptionInternal(generalException, errorReasonHttpStatus, null, request);
     }
 
     private ResponseEntity<Object> handleExceptionInternal(
-            Exception e, GlobalErrorCode errorCode, HttpHeaders headers, HttpServletRequest request) {
+            Exception e, ErrorReasonDTO reason, HttpHeaders headers, HttpServletRequest request) {
 
         ApiResponse<Object> body =
-                ApiResponse.onFailure(errorCode, null);
+                ApiResponse.onFailure(reason.getCode(), reason.getMessage(), null);
         e.printStackTrace();
 
         WebRequest webRequest = new ServletWebRequest(request);
         return super.handleExceptionInternal(
-                e, body, headers, errorCode.getHttpStatus(), webRequest);
+                e, body, headers, reason.getHttpStatus(), webRequest);
     }
 
     private ResponseEntity<Object> handleExceptionInternalFalse(
@@ -121,7 +122,7 @@ public class GeneralExceptionHandler extends ResponseEntityExceptionHandler {
             WebRequest request,
             String errorPoint) {
         ApiResponse<Object> body =
-                ApiResponse.onFailure(errorCode, errorPoint);
+                ApiResponse.onFailure(errorCode.getCode(), errorCode.getMessage(), errorPoint);
         return super.handleExceptionInternal(e, body, headers, status, request);
     }
 
@@ -132,14 +133,14 @@ public class GeneralExceptionHandler extends ResponseEntityExceptionHandler {
             WebRequest request,
             Map<String, String> errorArgs) {
         ApiResponse<Object> body =
-                ApiResponse.onFailure(errorCode, errorArgs);
+                ApiResponse.onFailure(errorCode.getCode(), errorCode.getMessage(), errorArgs);
         return super.handleExceptionInternal(e, body, headers, errorCode.getHttpStatus(), request);
     }
 
     private ResponseEntity<Object> handleExceptionInternalConstraint(
             Exception e, GlobalErrorCode errorCode, HttpHeaders headers, WebRequest request) {
         ApiResponse<Object> body =
-                ApiResponse.onFailure(errorCode, null);
+                ApiResponse.onFailure(errorCode.getCode(), errorCode.getMessage(), null);
         return super.handleExceptionInternal(e, body, headers, errorCode.getHttpStatus(), request);
     }
 

--- a/src/main/java/org/example/tree/global/exception/GlobalErrorCode.java
+++ b/src/main/java/org/example/tree/global/exception/GlobalErrorCode.java
@@ -9,71 +9,84 @@ import static org.springframework.http.HttpStatus.BAD_REQUEST;
 
 @Getter
 @AllArgsConstructor
-public enum GlobalErrorCode {
+public enum GlobalErrorCode implements BaseErrorCode{
 
-    // Server Error
-    SERVER_ERROR(INTERNAL_SERVER_ERROR,"서버 에러, 서버 개발자에게 알려주세요."),
+    // 500 Server Error
+    SERVER_ERROR(INTERNAL_SERVER_ERROR, "GLOBAL500_1", "서버 에러, 서버 개발자에게 알려주세요."),
 
     // Args Validation Error
-    BAD_ARGS_ERROR(BAD_REQUEST, "request body의 validation이 실패했습니다. 응답 body를 참고해주세요"),
+    BAD_ARGS_ERROR(BAD_REQUEST, "GLOBAL400_1", "request body의 validation이 실패했습니다. 응답 body를 참고해주세요"),
 
     //  Member
     // 400 BAD_REQUEST - 잘못된 요청
-    NOT_VALID_PHONE_NUMBER(BAD_REQUEST, "유효하지 않은 전화번호 입니다."),
+    NOT_VALID_PHONE_NUMBER(BAD_REQUEST, "USER400_1", "유효하지 않은 전화번호 입니다."),
 
     // 401 Unauthorized - 권한 없음
-    INVALID_TOKEN(UNAUTHORIZED, "토큰이 유효하지 않습니다."),
-    INVALID_REFRESH_TOKEN(UNAUTHORIZED, "리프레시 토큰이 유효하지 않습니다."),
-    LOGIN_REQUIRED(UNAUTHORIZED, "로그인이 필요한 서비스입니다."),
+
     // 403 Forbidden - 인증 거부
-    AUTHENTICATION_DENIED(FORBIDDEN, "인증이 거부 되었습니다."),
-    AUTHENTICATION_REQUIRED(UNAUTHORIZED, "인증 정보가 유효하지 않습니다."),
+
     // 404 Not Found - 찾을 수 없음
-    NEED_AGREE_REQUIRE_TERMS(NOT_FOUND, "필수 약관에 동의해 주세요."),
-    MEMBER_NOT_FOUND(NOT_FOUND, "등록된 사용자 정보가 없습니다."),
-    REFRESH_TOKEN_NOT_FOUND(NOT_FOUND, "리프레시 토큰이 존재하지 않습니다."),
-    REFRESH_TOKEN_EXPIRED(NOT_FOUND, "리프레시 토큰이 만료 되었습니다."),
-    TOKEN_EXPIRED(NOT_FOUND, "토큰이 만료 되었습니다."),
+    MEMBER_NOT_FOUND(NOT_FOUND, "USER404_1", "등록된 사용자 정보가 없습니다."),
+
+
     // 409 CONFLICT : Resource 를 찾을 수 없음
-    DUPLICATE_PHONE_NUMBER(CONFLICT, "중복된 전화번호가 존재합니다."),
+    DUPLICATE_PHONE_NUMBER(CONFLICT, "USER409_1", "중복된 전화번호가 존재합니다."),
 
     //Profile
     //404 Not Found - 찾을 수 없음
-    PROFILE_NOT_FOUND(NOT_FOUND, "존재하지 않는 프로필입니다."),
-    AVAILABLE_PROFILE_NOT_FOUND(NOT_FOUND, "현재 선택된 프로필이 없습니다."),
+    PROFILE_NOT_FOUND(NOT_FOUND, "MEMBER404_1", "존재하지 않는 프로필입니다."),
+    AVAILABLE_PROFILE_NOT_FOUND(NOT_FOUND, "MEMBER404_2", "현재 선택된 프로필이 없습니다."),
 
-    //Tree
+    //Treehouse
     //404 Not Found - 찾을 수 없음
-    TREE_NOT_FOUND(NOT_FOUND, "존재하지 않는 트리입니다."),
+    TREEHOUSE_NOT_FOUND(NOT_FOUND, "TREEHOUSE404_1", "존재하지 않는 트리입니다."),
 
     //Invitation
     //404 Not Found - 찾을 수 없음
-    INVITATION_NOT_FOUND(NOT_FOUND, "존재하지 않는 초대장입니다."),
+    INVITATION_NOT_FOUND(NOT_FOUND, "INVITATION404_1", "존재하지 않는 초대장입니다."),
 
     //Post
     //404 Not Found - 찾을 수 없음
-    POST_NOT_FOUND(NOT_FOUND, "존재하지 않는 게시글입니다."),
+    POST_NOT_FOUND(NOT_FOUND, "POST404_1", "존재하지 않는 게시글입니다."),
 
     //Comment
     //404 Not Found - 찾을 수 없음
-    COMMENT_NOT_FOUND(NOT_FOUND, "존재하지 않는 댓글입니다."),
+    COMMENT_NOT_FOUND(NOT_FOUND, "COMMENT404_1", "존재하지 않는 댓글입니다."),
 
     //Reply
     //404 Not Found - 찾을 수 없음
-    REPLY_NOT_FOUND(NOT_FOUND, "존재하지 않는 답글입니다."),
+    REPLY_NOT_FOUND(NOT_FOUND, "REPLY404_1", "존재하지 않는 답글입니다."),
 
     //Branch
     //404 Not Found - 찾을 수 없음
-    BRANCH_NOT_FOUND(NOT_FOUND, "브랜치 정보를 찾을 수 없습니다."),
+    BRANCH_NOT_FOUND(NOT_FOUND, "BRANCH404_1", "브랜치 정보를 찾을 수 없습니다."),
 
     //Notification
     //404 Not Found - 찾을 수 없음
-    NOTIFICATION_NOT_FOUND(NOT_FOUND, "알림이 없습니다."),
+    NOTIFICATION_NOT_FOUND(NOT_FOUND, "NOTIFICATION", "존재하지 않는 알림입니다."),
     ;
 
-
-
-
     private final HttpStatus httpStatus;
+    private final String code;
     private final String message;
+
+    @Override
+    public ErrorReasonDTO getReason() {
+        return ErrorReasonDTO.builder()
+                .message(message)
+                .code(code)
+                .isSuccess(false)
+                .build();
+    }
+
+    @Override
+    public ErrorReasonDTO getReasonHttpStatus() {
+        return ErrorReasonDTO.builder()
+                .message(message)
+                .code(code)
+                .httpStatus(httpStatus)
+                .isSuccess(false)
+                .build();
+    }
+
 }

--- a/src/main/java/org/example/tree/global/exception/JwtAuthenticationException.java
+++ b/src/main/java/org/example/tree/global/exception/JwtAuthenticationException.java
@@ -4,7 +4,7 @@ import org.springframework.security.core.AuthenticationException;
 
 public class JwtAuthenticationException extends AuthenticationException {
 
-    public JwtAuthenticationException(GlobalErrorCode code) {
+    public JwtAuthenticationException(AuthErrorCode code) {
         super(code.name());
     }
 }

--- a/src/main/java/org/example/tree/global/security/filter/JwtAuthFilter.java
+++ b/src/main/java/org/example/tree/global/security/filter/JwtAuthFilter.java
@@ -9,6 +9,7 @@ import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.example.tree.global.common.ApiResponse;
+import org.example.tree.global.exception.AuthErrorCode;
 import org.example.tree.global.exception.GlobalErrorCode;
 import org.example.tree.global.security.provider.TokenProvider;
 import org.springframework.http.HttpStatus;
@@ -63,12 +64,15 @@ public class JwtAuthFilter extends OncePerRequestFilter {
 
 
     // JWT 인증과 관련된 예외 처리
-    public void jwtExceptionHandler(HttpServletResponse response, String msg, int statusCode) {
-        response.setStatus(statusCode);
+    public void jwtExceptionHandler(HttpServletResponse response, AuthErrorCode errorCode) {
+        response.setStatus(errorCode.getHttpStatus().value());
         response.setContentType("application/json");
 
         try {
-            String json = new ObjectMapper().writeValueAsString(ApiResponse.onFailure(GlobalErrorCode.INVALID_TOKEN, msg));
+            // AuthErrorCode로부터 code와 message 추출
+            String code = errorCode.getCode();
+            String message = errorCode.getMessage();
+            String json = new ObjectMapper().writeValueAsString(ApiResponse.onFailure(code, message, null)); // ApiResponse 객체를 JSON으로 변환
             response.getWriter().write(json);
         } catch (Exception e) {
             log.error(e.getMessage());

--- a/src/main/java/org/example/tree/global/security/handler/JwtAccessDeniedHandler.java
+++ b/src/main/java/org/example/tree/global/security/handler/JwtAccessDeniedHandler.java
@@ -4,6 +4,7 @@ import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import org.example.tree.global.common.ApiResponse;
+import org.example.tree.global.exception.AuthErrorCode;
 import org.example.tree.global.exception.GlobalErrorCode;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -28,7 +29,10 @@ public class JwtAccessDeniedHandler implements AccessDeniedHandler {
         response.setStatus(403);
         PrintWriter writer = response.getWriter();
 
-        ApiResponse<String> apiErrorResult = ApiResponse.onFailure(GlobalErrorCode.AUTHENTICATION_DENIED, "");
+        // AuthErrorCode.AUTHENTICATION_DENIED enum에서 코드와 메시지를 얻음
+        String code = AuthErrorCode.AUTHENTICATION_DENIED.getCode();
+        String message = AuthErrorCode.AUTHENTICATION_DENIED.getMessage();
+        ApiResponse<String> apiErrorResult = ApiResponse.onFailure(code, message, null);
         writer.write(apiErrorResult.toString());
         writer.flush();
         writer.close();

--- a/src/main/java/org/example/tree/global/security/handler/JwtAuthenticationEntryPoint.java
+++ b/src/main/java/org/example/tree/global/security/handler/JwtAuthenticationEntryPoint.java
@@ -4,6 +4,7 @@ import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import org.example.tree.global.common.ApiResponse;
+import org.example.tree.global.exception.AuthErrorCode;
 import org.example.tree.global.exception.GlobalErrorCode;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -28,7 +29,10 @@ public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
         response.setStatus(401);
         PrintWriter writer = response.getWriter();
 
-        ApiResponse<String> apiErrorResult = ApiResponse.onFailure(GlobalErrorCode.AUTHENTICATION_REQUIRED, "");
+        // AuthErrorCode.AUTHENTICATION_REQUIRED enum에서 코드와 메시지를 얻음
+        String code = AuthErrorCode.AUTHENTICATION_REQUIRED.getCode();
+        String message = AuthErrorCode.AUTHENTICATION_REQUIRED.getMessage();
+        ApiResponse<String> apiErrorResult = ApiResponse.onFailure(code, message, null);
 
         writer.write(apiErrorResult.toString());
         writer.flush();

--- a/src/main/java/org/example/tree/global/security/handler/JwtAuthenticationExceptionHandler.java
+++ b/src/main/java/org/example/tree/global/security/handler/JwtAuthenticationExceptionHandler.java
@@ -5,6 +5,7 @@ import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import org.example.tree.global.common.ApiResponse;
+import org.example.tree.global.exception.AuthErrorCode;
 import org.example.tree.global.exception.GlobalErrorCode;
 import org.example.tree.global.exception.JwtAuthenticationException;
 import org.example.tree.global.exception.JwtReissueException;
@@ -28,7 +29,8 @@ public class JwtAuthenticationExceptionHandler extends OncePerRequestFilter {
 
             PrintWriter writer = response.getWriter();
             String errorCodeName = authException.getMessage();
-            ApiResponse<String> apiErrorResult = ApiResponse.onFailure(GlobalErrorCode.valueOf(errorCodeName), "");
+            AuthErrorCode errorCode = AuthErrorCode.valueOf(errorCodeName);
+            ApiResponse<String> apiErrorResult = ApiResponse.onFailure(errorCode.getCode(),errorCode.getMessage(), null);
 
             writer.write(apiErrorResult.toString());
             writer.flush();

--- a/src/main/java/org/example/tree/global/security/provider/TokenProvider.java
+++ b/src/main/java/org/example/tree/global/security/provider/TokenProvider.java
@@ -8,9 +8,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.example.tree.domain.member.entity.Member;
 import org.example.tree.domain.member.service.MemberQueryService;
-import org.example.tree.global.exception.GeneralException;
-import org.example.tree.global.exception.GlobalErrorCode;
-import org.example.tree.global.exception.JwtAuthenticationException;
+import org.example.tree.global.exception.*;
 import org.example.tree.global.redis.service.RedisService;
 import org.springframework.beans.factory.annotation.Value;
 
@@ -119,7 +117,7 @@ public class TokenProvider {
             log.error("Invalid JWT signature, 유효하지 않는 JWT 서명 입니다.");
         } catch (ExpiredJwtException e) {
             log.info("Expired JWT token, 만료된 JWT token 입니다.");
-            throw new JwtAuthenticationException(GlobalErrorCode.TOKEN_EXPIRED);
+            throw new JwtAuthenticationException(AuthErrorCode.TOKEN_EXPIRED);
 
         } catch (UnsupportedJwtException e) {
             log.error("Unsupported JWT token, 지원되지 않는 JWT 토큰 입니다.");
@@ -137,20 +135,20 @@ public class TokenProvider {
             Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(refreshToken);
         } catch (SecurityException | MalformedJwtException e) {
             log.error("Invalid JWT signature, 유효하지 않는 JWT 서명 입니다.");
-            throw new GeneralException(GlobalErrorCode.INVALID_TOKEN);
+            throw new AuthException(AuthErrorCode.INVALID_TOKEN);
         } catch (ExpiredJwtException e) {
             log.info("Expired JWT token, 만료된 JWT 리프레시 token 입니다.");
-            throw new GeneralException(GlobalErrorCode.REFRESH_TOKEN_EXPIRED);
+            throw new AuthException(AuthErrorCode.REFRESH_TOKEN_EXPIRED);
         } catch (UnsupportedJwtException e) {
             log.error("Unsupported JWT token, 지원되지 않는 JWT 토큰 입니다.");
-            throw new GeneralException(GlobalErrorCode.INVALID_TOKEN);
+            throw new AuthException(AuthErrorCode.INVALID_TOKEN);
         } catch (IllegalArgumentException e) {
             log.error("JWT claims is empty, 잘못된 JWT 토큰 입니다.");
-            throw new GeneralException(GlobalErrorCode.INVALID_TOKEN);
+            throw new AuthException(AuthErrorCode.INVALID_TOKEN);
         }
         catch (io.jsonwebtoken.security.SignatureException e){
             log.error("Invalid JWT signature, 유효하지 않는 JWT 서명 입니다");
-            throw new GeneralException(GlobalErrorCode.INVALID_TOKEN);
+            throw new AuthException(AuthErrorCode.INVALID_TOKEN);
         }
     }
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -65,8 +65,8 @@ jwt:
     key: ${JWT_SECRET}
   #  secret : ${JWT_SECRET}
   authorities-key: authoritiesKey
-  access-token-validity-in-seconds: 300000 # 30 m
-  refresh-token-validity-in-seconds: 360000 # 14 d
+  access-token-validity-in-seconds: 300000 # 5 m
+  refresh-token-validity-in-seconds: 360000 # 6 d
 
 
 


### PR DESCRIPTION
# 🚀 개요
<!-- 이 PR을 간략하게 설명해주세요 -->
기존의 `GeneralException` 과 `GlobalErrorCode` 로만 관리하던 예외처리 방식에서 도메인 별 예외처리로 변경하여 관리하도록 변경
## 🔍 변경사항
<!-- 이 PR로 인해 바뀌게 되는 것들을 목록으로 적어주세요. -->
- 에러 코드 구조를 `httpStatus` + 'code` + `message` 구조로 변경
- `code` 부분을 "PREFIX + code" 구조로 변경하여 API 연결 테스트 시, 더 직관적으로 오류의 원인을 찾을 수 있도록 변경
- 로그인/회원가입 서비스 로직에서 예외 발생 시, `AuthException` 을 던지도록 변경

## ⏳ 작업 내용
- [x] `BaseErrorCode`를 이용하여 도메인 별 에러코드로 구조화
- [x] 에러 코드의 구조를 `httpStatus` + 'code` + `message` 구조로 변경
- [x] 에러코드의 `code` 부분을 "PREFIX + code" 구조로 변경하여 API 연결 테스트 시, 더 직관적으로 오류의 원인을 찾을 수 있도록 변경
- [x] JWT 토큰 관련에서 발생하는 예외와 로그인/회원가입 서비스 로직에서 발생하는 예외에 대해 `AuthException` 을 던지도록 변경

### 📝 논의사항
<!-- 이 PR에 대한 논의하고 싶은 사항이나, 더 해야할 작업, 리뷰어에게 특별히 확인 요청하고 싶은 부분 등을 적어주세요. -->
예외처리 리팩토링 과정에서 JWT 관련 Exception에 대한 처리 부분도 건드렸는데 추후에 문제가 없을 지 궁금합니다!
