### PR TITLE
[REFACTOR]/#85 - Converter와 ResponseDTO들 리팩토링

### DIFF
--- a/src/main/java/org/example/tree/domain/invitation/controller/InvitationController.java
+++ b/src/main/java/org/example/tree/domain/invitation/controller/InvitationController.java
@@ -35,7 +35,7 @@ public class InvitationController {
         return ApiResponse.onSuccess("");
     }
 
-    @PostMapping("/trees/members/invitation/accept")
+    @PostMapping("/treehouses/members/invitation/accept")
     @Operation(summary = "초대 수락", description = "받은 초대를 수락합니다.")
     public ApiResponse<InvitationResponseDTO.acceptInvitation> acceptInvitation(
             @RequestBody final InvitationRequestDTO.acceptInvitation request
@@ -43,7 +43,7 @@ public class InvitationController {
         return ApiResponse.onSuccess(invitationService.acceptInvitation(request));
     }
 
-    @PostMapping("/trees/members/invitation/reject")
+    @PostMapping("/treehouses/members/invitation/reject")
     @Operation(summary = "초대 거절", description = "받은 초대를 거절합니다.")
     public ApiResponse<InvitationResponseDTO.rejectInvitation> rejectInvitation(
             @RequestBody final InvitationRequestDTO.rejectInvitation request
@@ -53,10 +53,10 @@ public class InvitationController {
 
     @GetMapping("/users/invitation")
     @Operation(summary = "초대장 조회", description = "내가 받은 초대장을 조회합니다.")
-    public ApiResponse<List<InvitationResponseDTO.getInvitation>> getInvitation(
+    public ApiResponse<InvitationResponseDTO.getInvitations> getInvitations(
             @AuthMember @Parameter(hidden = true) Member member
     ) {
-        return ApiResponse.onSuccess(invitationService.getInvitation(member));
+        return ApiResponse.onSuccess(invitationService.getInvitations(member));
     }
 
     @GetMapping("/users/availableInvitation")

--- a/src/main/java/org/example/tree/domain/invitation/converter/InvitationConverter.java
+++ b/src/main/java/org/example/tree/domain/invitation/converter/InvitationConverter.java
@@ -31,14 +31,14 @@ public class InvitationConverter {
 
     public InvitationResponseDTO.acceptInvitation toAcceptInvitation (Invitation invitation) {
         return InvitationResponseDTO.acceptInvitation.builder()
-                .treeId(invitation.getTree().getId())
+                .treehouseId(invitation.getTree().getId())
                 .isAccepted(true)
                 .build();
     }
 
     public InvitationResponseDTO.rejectInvitation toRejectInvitation (Invitation invitation) {
         return InvitationResponseDTO.rejectInvitation.builder()
-                .treeId(invitation.getTree().getId())
+                .treehouseId(invitation.getTree().getId())
                 .isAccepted(false)
                 .build();
     }
@@ -59,5 +59,11 @@ public class InvitationConverter {
                 .treehouseSize(invitation.getTree().getTreeSize())
                 .treehouseMemberProfileImages(treeMemberProfileImages)
                 .build();
+    }
+
+    public InvitationResponseDTO.getInvitations toGetInvitations(List<InvitationResponseDTO.getInvitation> invitationDtos) {
+       return InvitationResponseDTO.getInvitations.builder()
+               .invitations(invitationDtos)
+               .build();
     }
 }

--- a/src/main/java/org/example/tree/domain/invitation/dto/InvitationRequestDTO.java
+++ b/src/main/java/org/example/tree/domain/invitation/dto/InvitationRequestDTO.java
@@ -10,7 +10,7 @@ public class InvitationRequestDTO {
     @Getter
     public static class sendInvitation {
         private Long senderId;
-        private Long treeId;
+        private Long treehouseId;
         private String phoneNumber;
     }
 

--- a/src/main/java/org/example/tree/domain/invitation/dto/InvitationResponseDTO.java
+++ b/src/main/java/org/example/tree/domain/invitation/dto/InvitationResponseDTO.java
@@ -21,7 +21,7 @@ public class InvitationResponseDTO {
     @NoArgsConstructor
     @AllArgsConstructor
     public static class acceptInvitation {
-        private Long treeId;
+        private Long treehouseId;
         private Boolean isAccepted;
     }
 
@@ -30,7 +30,7 @@ public class InvitationResponseDTO {
     @NoArgsConstructor
     @AllArgsConstructor
     public static class rejectInvitation {
-        private Long treeId;
+        private Long treehouseId;
         private Boolean isAccepted;
     }
 
@@ -45,6 +45,14 @@ public class InvitationResponseDTO {
         private String senderProfileImageUrl;
         private Integer treehouseSize;
         private List<String> treehouseMemberProfileImages;
+    }
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class getInvitations {
+        List<InvitationResponseDTO.getInvitation> invitations;
     }
 
     @Builder

--- a/src/main/java/org/example/tree/domain/invitation/service/InvitationService.java
+++ b/src/main/java/org/example/tree/domain/invitation/service/InvitationService.java
@@ -2,7 +2,6 @@ package org.example.tree.domain.invitation.service;
 
 
 import lombok.RequiredArgsConstructor;
-import org.example.tree.domain.branch.service.BranchService;
 import org.example.tree.domain.invitation.converter.InvitationConverter;
 import org.example.tree.domain.invitation.dto.InvitationRequestDTO;
 import org.example.tree.domain.invitation.dto.InvitationResponseDTO;
@@ -18,7 +17,6 @@ import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
@@ -37,7 +35,7 @@ public class InvitationService {
     public InvitationResponseDTO.sendInvitation inviteUser(InvitationRequestDTO.sendInvitation request) {
         Member member = memberQueryService.findById(request.getSenderId());
         member.decreaseInvitationCount();
-        Tree tree = treeQueryService.findById(request.getTreeId());
+        Tree tree = treeQueryService.findById(request.getTreehouseId());
         Profile sender = profileQueryService.getTreeProfile(member, tree);
         Invitation invitation = invitationConverter.toInvitation(sender, tree, request.getPhoneNumber());
         Optional<Member> optionalMember = memberQueryService.findByPhoneNumber(request.getPhoneNumber());
@@ -78,9 +76,9 @@ public class InvitationService {
     }
 
     @Transactional
-    public List<InvitationResponseDTO.getInvitation> getInvitation(Member member) {
-        List<Invitation> invitations= invitationQueryService.findAllByPhone(member.getPhone());
-        return invitations.stream()
+    public InvitationResponseDTO.getInvitations getInvitations(Member member) {
+        List<Invitation> invitations = invitationQueryService.findAllByPhone(member.getPhone());
+        List<InvitationResponseDTO.getInvitation> invitationDtos = invitations.stream()
                 .map(invitation -> {
                     Tree tree = invitation.getTree(); // Invitation에서 Tree 정보를 가져옵니다.
                     List<Profile> treeMembers = profileQueryService.findTreeMembers(tree); // Tree의 모든 멤버를 조회합니다.
@@ -89,11 +87,13 @@ public class InvitationService {
                     List<String> randomProfileImages = treeMembers.stream()
                             .map(Profile::getProfileImageUrl)
                             .limit(3) // 최대 3명
-                            .collect(Collectors.toList());
+                            .toList();
 
                     // toGetInvitation 메소드를 수정하여, 선택된 멤버의 profileImage 정보를 포함시켜야 합니다.
                     return invitationConverter.toGetInvitation(invitation, randomProfileImages);
                 })
                 .collect(Collectors.toList());
+
+        return invitationConverter.toGetInvitations(invitationDtos);
     }
 }

--- a/src/main/java/org/example/tree/domain/member/controller/MemberController.java
+++ b/src/main/java/org/example/tree/domain/member/controller/MemberController.java
@@ -15,8 +15,8 @@ public class MemberController {
     private final MemberService memberService;
 
 
-    @PostMapping("/checkId")
-    @Operation(summary = "아이디 중복 체크", description = "서비스에서 사용할 고유 ID를 중복 체크합니다.")
+    @PostMapping("/checkName")
+    @Operation(summary = "아이디 중복 체크", description = "서비스에서 사용할 유저이름을 중복 체크합니다.")
     public ApiResponse<MemberResponseDTO.checkName> checkName(
             @RequestBody final MemberRequestDTO.checkName request
     ) {

--- a/src/main/java/org/example/tree/domain/member/converter/MemberConverter.java
+++ b/src/main/java/org/example/tree/domain/member/converter/MemberConverter.java
@@ -31,7 +31,7 @@ public class MemberConverter {
         return staticMemberQueryService.findById(Long.valueOf(id));
     }
 
-    public Member toMember (String userName, String phone) {
+    public static Member toMember (String userName, String phone) {
         return Member.builder()
                 .userName(userName)
                 .phone(phone)
@@ -40,13 +40,13 @@ public class MemberConverter {
                 .build();
     }
 
-    public MemberResponseDTO.checkName toCheckName(Boolean isDuplicated) {
+    public static MemberResponseDTO.checkName toCheckName(Boolean isDuplicated) {
         return MemberResponseDTO.checkName.builder()
                 .isDuplicated(isDuplicated)
                 .build();
     }
 
-    public MemberResponseDTO.registerMember toRegister(Member member, String accessToken, String refreshToken) {
+    public static MemberResponseDTO.registerMember toRegister(Member member, String accessToken, String refreshToken) {
         return MemberResponseDTO.registerMember.builder()
                 .userId(member.getId())
                 .accessToken(accessToken)
@@ -54,7 +54,7 @@ public class MemberConverter {
                 .build();
     }
 
-    public MemberResponseDTO.reissue toReissue(String accessToken, String refreshToken) {
+    public static MemberResponseDTO.reissue toReissue(String accessToken, String refreshToken) {
         return MemberResponseDTO.reissue.builder()
                 .accessToken(accessToken)
                 .refreshToken(refreshToken)

--- a/src/main/java/org/example/tree/domain/member/service/MemberService.java
+++ b/src/main/java/org/example/tree/domain/member/service/MemberService.java
@@ -29,8 +29,8 @@ public class MemberService {
     @Transactional
     public MemberResponseDTO.checkName checkName(MemberRequestDTO.checkName request) {
         Optional<Member> optionalMember = memberQueryService.checkName(request.getUserName());
-        Boolean isDuplicate = optionalMember.isPresent();
-        return memberConverter.toCheckName(isDuplicate);
+        Boolean isDuplicated = optionalMember.isPresent();
+        return memberConverter.toCheckName(isDuplicated);
     }
     @Transactional
     public MemberResponseDTO.registerMember register(MemberRequestDTO.registerMember request) {

--- a/src/main/java/org/example/tree/domain/profile/controller/ProfileController.java
+++ b/src/main/java/org/example/tree/domain/profile/controller/ProfileController.java
@@ -18,23 +18,25 @@ import org.springframework.web.multipart.MultipartFile;
 public class ProfileController {
     private final ProfileService profileService;
 
-    @PostMapping("/trees/owner/register")
-    @Operation(summary = "트리하우스 설립자 프로필 등록", description = "트리하우스 오너 프로필을 등록합니다.")
-    public ApiResponse registerTreeOwner(
-            @RequestBody ProfileRequestDTO.ownerProfile request
+    @PostMapping("/treehouses/owner/register")
+    @Operation(summary = "트리하우스 설립자 등록", description = "트리하우스의 설립자(Owner)로 등록합니다.")
+    public ApiResponse registerTreehouseOwner(
+            @RequestBody ProfileRequestDTO.ownerProfile request,
+            @AuthMember @Parameter(hidden = true) Member member
     ) throws Exception {
-        return ApiResponse.onSuccess(profileService.ownerProfile(request));
+        return ApiResponse.onSuccess(profileService.ownerProfile(request, member));
     }
 
-    @PostMapping("/trees/members/register")
-    @Operation(summary = "트리하우스 멤버 프로필 등록", description = "트리하우스 멤버 프로필을 등록합니다.")
-    public ApiResponse registerTreeMember(
-            @RequestBody ProfileRequestDTO.createProfile request
+    @PostMapping("/treehouses/members/register")
+    @Operation(summary = "트리하우스 멤버 가입", description = "트리하우스의 멤버로 등록합니다.")
+    public ApiResponse registerTreehouseMember(
+            @RequestBody ProfileRequestDTO.createProfile request,
+            @AuthMember @Parameter(hidden = true) Member member
             ) throws Exception {
-        return ApiResponse.onSuccess(profileService.createProfile(request));
+        return ApiResponse.onSuccess(profileService.createProfile(request, member));
     }
 
-    @GetMapping("/trees/{treeId}/members/{profileId}") //프로필 조회
+    @GetMapping("/treehouses/{treeId}/members/{profileId}") //프로필 조회
     @Operation(summary = "멤버 프로필 조회", description = "트리하우스 속 특정 멤버의 프로필을 조회합니다.")
     public ApiResponse getProfileDetails(
             @AuthMember @Parameter(hidden = true) Member member,
@@ -43,7 +45,7 @@ public class ProfileController {
         return ApiResponse.onSuccess(profileService.getProfileDetails(member, profileId));
     }
 
-    @GetMapping("/trees/{treeId}/myProfile") //내 프로필 조회
+    @GetMapping("/treehouses/{treeId}/myProfile") //내 프로필 조회
     @Operation(summary = "내 프로필 조회", description = "트리하우스 속 내 프로필을 조회합니다.")
     public ApiResponse getMyProfile(
             @AuthMember @Parameter(hidden = true) Member member,

--- a/src/main/java/org/example/tree/domain/profile/converter/ProfileConverter.java
+++ b/src/main/java/org/example/tree/domain/profile/converter/ProfileConverter.java
@@ -11,7 +11,7 @@ import java.util.List;
 
 @Component
 public class ProfileConverter {
-    public Profile toProfile (Tree tree, Member member, String memberName, String bio, String profileImageUrl) {
+    public static Profile toProfile (Tree tree, Member member, String memberName, String bio, String profileImageUrl) {
         return Profile.builder()
                 .tree(tree)
                 .member(member)
@@ -22,16 +22,14 @@ public class ProfileConverter {
                 .build();
     }
 
-    public ProfileResponseDTO.createProfile toCreateProfile(Profile profile) {
+    public static ProfileResponseDTO.createProfile toCreateProfile(Profile profile) {
         return ProfileResponseDTO.createProfile.builder()
-                .profileId(profile.getId())
-                .treeId(profile.getTree().getId())
-                .memberName(profile.getMemberName())
-                .profileImageUrl(profile.getProfileImageUrl())
+                .userId(profile.getMember().getId())
+                .treehouseId(profile.getTree().getId())
                 .build();
     }
 
-    public ProfileResponseDTO.getProfileDetails toGetProfileDetails(Profile profile, List<Long> treeIds, int branchDegree) {
+    public static ProfileResponseDTO.getProfileDetails toGetProfileDetails(Profile profile, List<Long> treeIds, int branchDegree) {
         return ProfileResponseDTO.getProfileDetails.builder()
                 .profileId(profile.getId())
                 .treeIds(treeIds)

--- a/src/main/java/org/example/tree/domain/profile/dto/ProfileRequestDTO.java
+++ b/src/main/java/org/example/tree/domain/profile/dto/ProfileRequestDTO.java
@@ -9,20 +9,20 @@ import org.springframework.web.multipart.MultipartFile;
 public class ProfileRequestDTO {
     @Getter
     public static class createProfile {
-        private Long treeId;
-        private Long userId;
+        private Long treehouseId;
+        private String userName;
         private String memberName;
-        private String profileImage;
+        private String profileImageURL;
         private String bio;
 
     }
 
     @Getter
     public static class ownerProfile {
-        private Long treeId;
-        private Long userId;
+        private Long treehouseId;
+        private String userName;
         private String memberName;
-        private String profileImage;
+        private String profileImageURL;
         private String bio;
 
     }

--- a/src/main/java/org/example/tree/domain/profile/dto/ProfileResponseDTO.java
+++ b/src/main/java/org/example/tree/domain/profile/dto/ProfileResponseDTO.java
@@ -12,10 +12,8 @@ public class ProfileResponseDTO {
     @NoArgsConstructor
     @AllArgsConstructor
     public static class createProfile {
-        private Long profileId;
-        private Long treeId;
-        private String memberName;
-        private String profileImageUrl;
+        private Long userId;
+        private Long treehouseId;
     }
 
     @Builder

--- a/src/main/java/org/example/tree/domain/profile/service/ProfileService.java
+++ b/src/main/java/org/example/tree/domain/profile/service/ProfileService.java
@@ -33,16 +33,15 @@ public class ProfileService {
     private final InvitationQueryService invitationQueryService;
 
     @Transactional
-    public ProfileResponseDTO.createProfile createProfile(ProfileRequestDTO.createProfile request) throws Exception {
-        Tree tree = treeQueryService.findById(request.getTreeId());
-        Member member = memberQueryService.findById(request.getUserId());
+    public ProfileResponseDTO.createProfile createProfile(ProfileRequestDTO.createProfile request, Member member) throws Exception {
+        Tree tree = treeQueryService.findById(request.getTreehouseId());
         boolean isNewUser = profileQueryService.isNewUser(member);
         if (!isNewUser) {
             Profile currentProfile = profileQueryService.getCurrentProfile(member);
             currentProfile.inactivate();
             profileCommandService.updateProfile(currentProfile);
         }
-        String profileImageUrl = request.getProfileImage() == null ? DEFAULT_PROFILE_IMAGE : request.getProfileImage();
+        String profileImageUrl = request.getProfileImageURL() == null ? DEFAULT_PROFILE_IMAGE : request.getProfileImageURL();
         Profile newProfile = profileConverter.toProfile(tree, member, request.getMemberName(), request.getBio(), profileImageUrl);
         profileCommandService.createProfile(newProfile);
         tree.increaseTreeSize();
@@ -53,16 +52,15 @@ public class ProfileService {
     }
 
     @Transactional
-    public ProfileResponseDTO.createProfile ownerProfile(ProfileRequestDTO.ownerProfile request) throws Exception {
-        Tree tree = treeQueryService.findById(request.getTreeId());
-        Member member = memberQueryService.findById(request.getUserId());
+    public ProfileResponseDTO.createProfile ownerProfile(ProfileRequestDTO.ownerProfile request, Member member) throws Exception {
+        Tree tree = treeQueryService.findById(request.getTreehouseId());
         boolean isNewUser = profileQueryService.isNewUser(member);
         if (!isNewUser) {
             Profile currentProfile = profileQueryService.getCurrentProfile(member);
             currentProfile.inactivate();
             profileCommandService.updateProfile(currentProfile);
         }
-        String profileImageUrl = request.getProfileImage() == null ? DEFAULT_PROFILE_IMAGE : request.getProfileImage();
+        String profileImageUrl = request.getProfileImageURL() == null ? DEFAULT_PROFILE_IMAGE : request.getProfileImageURL();
         Profile newProfile = profileConverter.toProfile(tree, member, request.getMemberName(), request.getBio(), profileImageUrl);
         profileCommandService.createProfile(newProfile);
         tree.increaseTreeSize();


### PR DESCRIPTION
# 🚀 개요
<!-- 이 PR을 간략하게 설명해주세요 -->
회원가입, 로그인 관련 로직에 참조되는 Converter 클래스들을 static으로 선언
회원가입, 로그인 관련 로직에서 오고가는 DTO들의 구조를 API 명세서에 맞게 수정
## 🔍 변경사항
<!-- 이 PR로 인해 바뀌게 되는 것들을 목록으로 적어주세요. -->
- 닉네임 중복확인 API URL 변경 
- 트리하우스 초대 수락/거부 API 응답 DTO 변경
- 트리하우스 멤버 가입 API 응답 DTO 변경
- 내가 받은 초대장 조회 API 응답 DTO 변경 

## ⏳ 작업 내용
- [x] 닉네임 중복확인 API URL 변경 
- [x] 트리하우스 초대 수락/거부 API 응답 DTO 변경
- [x] 트리하우스 멤버 가입 API 응답 DTO 변경
- [x] 내가 받은 초대장 조회 API 응답 DTO 변경

### 📝 논의사항
<!-- 이 PR에 대한 논의하고 싶은 사항이나, 더 해야할 작업, 리뷰어에게 특별히 확인 요청하고 싶은 부분 등을 적어주세요. -->
내가 받은 초대장 조회 API (`InvitationService`)의 `getInvitations` 메서드에 초대장이 발신된 트리하우스 속 멤버들의 프로필 이미지를 포함시키는 로직이 있는데 개선의 여지가 있어보인다면 어떻게 고치는 게 좋을 지 궁금합니다!
