### PR TITLE
[REFACTOR]/#86 - ApiResponse 클래스명을 CommonResponse로 변경

### DIFF
--- a/src/main/java/org/example/tree/domain/branch/controller/BranchController.java
+++ b/src/main/java/org/example/tree/domain/branch/controller/BranchController.java
@@ -5,7 +5,7 @@ import lombok.RequiredArgsConstructor;
 import org.example.tree.domain.branch.dto.BranchResponseDTO;
 import org.example.tree.domain.branch.service.BranchService;
 import org.example.tree.domain.member.entity.Member;
-import org.example.tree.global.common.ApiResponse;
+import org.example.tree.global.common.CommonResponse;
 import org.example.tree.global.security.handler.annotation.AuthMember;
 import org.springframework.web.bind.annotation.*;
 
@@ -16,18 +16,18 @@ public class BranchController {
     private final BranchService branchService;
 
     @GetMapping("/trees/{treeId}/branchView")
-    public ApiResponse<BranchResponseDTO.branchView> getBranchView(
+    public CommonResponse<BranchResponseDTO.branchView> getBranchView(
             @PathVariable Long treeId,
             @RequestParam("memberId") Long profileId,
             @AuthMember @Parameter(hidden = true) Member member
     ) {
-        return ApiResponse.onSuccess(branchService.getBranchView(treeId, member, profileId));
+        return CommonResponse.onSuccess(branchService.getBranchView(treeId, member, profileId));
     }
 
     @GetMapping("/trees/{treeId}/branchView/all")
-    public ApiResponse<BranchResponseDTO.branchView> getCompleteBranchView(
+    public CommonResponse<BranchResponseDTO.branchView> getCompleteBranchView(
             @PathVariable Long treeId
     ) {
-        return ApiResponse.onSuccess(branchService.getCompleteBranchView(treeId));
+        return CommonResponse.onSuccess(branchService.getCompleteBranchView(treeId));
     }
 }

--- a/src/main/java/org/example/tree/domain/comment/controller/CommentController.java
+++ b/src/main/java/org/example/tree/domain/comment/controller/CommentController.java
@@ -7,7 +7,7 @@ import org.example.tree.domain.comment.dto.CommentRequestDTO;
 import org.example.tree.domain.comment.dto.CommentResponseDTO;
 import org.example.tree.domain.comment.service.CommentService;
 import org.example.tree.domain.member.entity.Member;
-import org.example.tree.global.common.ApiResponse;
+import org.example.tree.global.common.CommonResponse;
 import org.example.tree.global.security.handler.annotation.AuthMember;
 import org.springframework.web.bind.annotation.*;
 
@@ -20,7 +20,7 @@ public class CommentController {
 
     @PostMapping("/trees/{treeId}/feed/posts/{postId}/comments")
     @Operation(summary = "댓글 작성", description = "특정 게시글에 댓글 작성합니다.")
-    public ApiResponse createComment(
+    public CommonResponse createComment(
             @PathVariable final Long treeId,
             @PathVariable final Long postId,
             @RequestBody final CommentRequestDTO.createComment request,
@@ -28,22 +28,22 @@ public class CommentController {
 
             ) {
         commentService.createComment(treeId, postId, request, member);
-        return ApiResponse.onSuccess("");
+        return CommonResponse.onSuccess("");
     }
 
     @GetMapping("/trees/{treeId}/feed/posts/{postId}/comments")
     @Operation(summary = "댓글 조회", description = "Reaction과 댓글에 달린 답글도 같이 출력됩니다.")
-    public ApiResponse<List<CommentResponseDTO.getComment>> getComments(
+    public CommonResponse<List<CommentResponseDTO.getComment>> getComments(
             @PathVariable final Long treeId,
             @PathVariable final Long postId,
             @AuthMember @Parameter(hidden = true) Member member
     ) {
-        return ApiResponse.onSuccess(commentService.getComments(treeId, postId, member));
+        return CommonResponse.onSuccess(commentService.getComments(treeId, postId, member));
     }
 
     @PatchMapping("/trees/{treeId}/feed/posts/{postId}/comments/{commentId}")
     @Operation(summary = "댓글 수정", description = "댓글을 수정합니다.")
-    public ApiResponse updateComment(
+    public CommonResponse updateComment(
             @PathVariable final Long treeId,
             @PathVariable final Long postId,
             @PathVariable final Long commentId,
@@ -51,18 +51,18 @@ public class CommentController {
             @AuthMember @Parameter(hidden = true) Member member
     ) {
         commentService.updateComment(treeId, postId, commentId, request, member);
-        return ApiResponse.onSuccess("");
+        return CommonResponse.onSuccess("");
     }
 
     @DeleteMapping("/trees/{treeId}/feed/posts/{postId}/comments/{commentId}")
     @Operation(summary = "댓글 삭제", description = "댓글을 삭제합니다.")
-    public ApiResponse deleteComment(
+    public CommonResponse deleteComment(
             @PathVariable final Long treeId,
             @PathVariable final Long postId,
             @PathVariable final Long commentId,
             @AuthMember @Parameter(hidden = true) Member member
     ) {
         commentService.deleteComment(treeId, postId, commentId, member);
-        return ApiResponse.onSuccess("");
+        return CommonResponse.onSuccess("");
     }
 }

--- a/src/main/java/org/example/tree/domain/comment/controller/ReplyController.java
+++ b/src/main/java/org/example/tree/domain/comment/controller/ReplyController.java
@@ -6,7 +6,7 @@ import lombok.RequiredArgsConstructor;
 import org.example.tree.domain.comment.dto.ReplyRequestDTO;
 import org.example.tree.domain.comment.service.ReplyService;
 import org.example.tree.domain.member.entity.Member;
-import org.example.tree.global.common.ApiResponse;
+import org.example.tree.global.common.CommonResponse;
 import org.example.tree.global.security.handler.annotation.AuthMember;
 import org.springframework.web.bind.annotation.*;
 
@@ -17,19 +17,19 @@ public class ReplyController {
 
     @PostMapping("/trees/{treeId}/feed/comments/{commentId}/reply")
     @Operation(summary = "답글 작성", description = "특정 댓글에 답글을 작성합니다.")
-    public ApiResponse createReply(
+    public CommonResponse createReply(
             @PathVariable final Long treeId,
             @PathVariable final Long commentId,
             @RequestBody final ReplyRequestDTO.createReply request,
             @AuthMember @Parameter(hidden = true) Member member
             ) {
         replyService.createReply(treeId, commentId, request, member);
-        return ApiResponse.onSuccess("");
+        return CommonResponse.onSuccess("");
     }
 
     @PatchMapping("/trees/{treeId}/feed/comments/{commentId}/reply/{replyId}")
     @Operation(summary = "답글 수정", description = "답글을 수정합니다.")
-    public ApiResponse updateReply(
+    public CommonResponse updateReply(
             @PathVariable final Long treeId,
             @PathVariable final Long commentId,
             @PathVariable final Long replyId,
@@ -37,19 +37,19 @@ public class ReplyController {
             @AuthMember @Parameter(hidden = true) Member member
     ) {
         replyService.updateReply(treeId, commentId, replyId, request, member);
-        return ApiResponse.onSuccess("");
+        return CommonResponse.onSuccess("");
     }
 
     @DeleteMapping("/trees/{treeId}/feed/comments/{commentId}/reply/{replyId}")
     @Operation(summary = "답글 삭제", description = "답글을 삭제합니다.")
-    public ApiResponse deleteReply(
+    public CommonResponse deleteReply(
             @PathVariable final Long treeId,
             @PathVariable final Long commentId,
             @PathVariable final Long replyId,
             @AuthMember @Parameter(hidden = true) Member member
     ) {
         replyService.deleteReply(treeId, commentId, replyId, member);
-        return ApiResponse.onSuccess("");
+        return CommonResponse.onSuccess("");
     }
 
 }

--- a/src/main/java/org/example/tree/domain/invitation/controller/InvitationController.java
+++ b/src/main/java/org/example/tree/domain/invitation/controller/InvitationController.java
@@ -7,11 +7,9 @@ import org.example.tree.domain.invitation.dto.InvitationRequestDTO;
 import org.example.tree.domain.invitation.dto.InvitationResponseDTO;
 import org.example.tree.domain.invitation.service.InvitationService;
 import org.example.tree.domain.member.entity.Member;
-import org.example.tree.global.common.ApiResponse;
+import org.example.tree.global.common.CommonResponse;
 import org.example.tree.global.security.handler.annotation.AuthMember;
 import org.springframework.web.bind.annotation.*;
-
-import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
@@ -20,50 +18,50 @@ public class InvitationController {
 
     @PostMapping("/users/invitation")
     @Operation(summary = "신규회원 초대", description = "서비스에 미가입된 사용자를 초대합니다.")
-    public ApiResponse<InvitationResponseDTO.sendInvitation> sendInvitation(
+    public CommonResponse<InvitationResponseDTO.sendInvitation> sendInvitation(
             @RequestBody final InvitationRequestDTO.sendInvitation request
     ) {
-        return ApiResponse.onSuccess(invitationService.inviteUser(request));
+        return CommonResponse.onSuccess(invitationService.inviteUser(request));
     }
 
     @PostMapping("/trees/members/invitation")
     @Operation(summary = "회원 초대", description = "서비스에 가입되어 있는 멤버를 다른 트리하우스에 초대합니다.")
-    public ApiResponse inviteMember(
+    public CommonResponse inviteMember(
             @RequestBody final InvitationRequestDTO.inviteMember request
     ) {
         invitationService.inviteMember(request);
-        return ApiResponse.onSuccess("");
+        return CommonResponse.onSuccess("");
     }
 
     @PostMapping("/treehouses/members/invitation/accept")
     @Operation(summary = "초대 수락", description = "받은 초대를 수락합니다.")
-    public ApiResponse<InvitationResponseDTO.acceptInvitation> acceptInvitation(
+    public CommonResponse<InvitationResponseDTO.acceptInvitation> acceptInvitation(
             @RequestBody final InvitationRequestDTO.acceptInvitation request
     ) {
-        return ApiResponse.onSuccess(invitationService.acceptInvitation(request));
+        return CommonResponse.onSuccess(invitationService.acceptInvitation(request));
     }
 
     @PostMapping("/treehouses/members/invitation/reject")
     @Operation(summary = "초대 거절", description = "받은 초대를 거절합니다.")
-    public ApiResponse<InvitationResponseDTO.rejectInvitation> rejectInvitation(
+    public CommonResponse<InvitationResponseDTO.rejectInvitation> rejectInvitation(
             @RequestBody final InvitationRequestDTO.rejectInvitation request
     ) {
-        return ApiResponse.onSuccess(invitationService.rejectInvitation(request));
+        return CommonResponse.onSuccess(invitationService.rejectInvitation(request));
     }
 
     @GetMapping("/users/invitation")
     @Operation(summary = "초대장 조회", description = "내가 받은 초대장을 조회합니다.")
-    public ApiResponse<InvitationResponseDTO.getInvitations> getInvitations(
+    public CommonResponse<InvitationResponseDTO.getInvitations> getInvitations(
             @AuthMember @Parameter(hidden = true) Member member
     ) {
-        return ApiResponse.onSuccess(invitationService.getInvitations(member));
+        return CommonResponse.onSuccess(invitationService.getInvitations(member));
     }
 
     @GetMapping("/users/availableInvitation")
     @Operation(summary = "가용 초대장 조회", description = "내가 보낼 수 있는 초대장 개수를 조회합니다.")
-    public ApiResponse<InvitationResponseDTO.getAvailableInvitation> getAvailableInvitation(
+    public CommonResponse<InvitationResponseDTO.getAvailableInvitation> getAvailableInvitation(
             @AuthMember @Parameter(hidden = true)  Member member
     ) {
-        return ApiResponse.onSuccess(invitationService.getAvailableInvitation(member));
+        return CommonResponse.onSuccess(invitationService.getAvailableInvitation(member));
     }
 }

--- a/src/main/java/org/example/tree/domain/member/controller/MemberController.java
+++ b/src/main/java/org/example/tree/domain/member/controller/MemberController.java
@@ -2,12 +2,13 @@ package org.example.tree.domain.member.controller;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import lombok.RequiredArgsConstructor;
 import org.example.tree.domain.member.dto.MemberRequestDTO;
 import org.example.tree.domain.member.dto.MemberResponseDTO;
 import org.example.tree.domain.member.service.MemberService;
-import org.example.tree.global.common.ApiResponse;
+import org.example.tree.global.common.CommonResponse;
 import org.example.tree.global.feign.service.NcpService;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.client.RestClientException;
@@ -27,59 +28,59 @@ public class MemberController {
 
     @PostMapping("/checkName")
     @Operation(summary = "아이디 중복 체크", description = "서비스에서 사용할 유저이름을 중복 체크합니다.")
-    public ApiResponse<MemberResponseDTO.checkName> checkName(
+    public CommonResponse<MemberResponseDTO.checkName> checkName(
             @RequestBody final MemberRequestDTO.checkName request
     ) {
-        return ApiResponse.onSuccess(memberService.checkName(request));
+        return CommonResponse.onSuccess(memberService.checkName(request));
     }
     @PostMapping("/register")
     @Operation(summary = "회원가입", description = "회원가입을 진행합니다.")
-    public ApiResponse<MemberResponseDTO.registerMember> registerMember(
+    public CommonResponse<MemberResponseDTO.registerMember> registerMember(
             @RequestBody final MemberRequestDTO.registerMember request
     ) {
-        return ApiResponse.onSuccess((memberService.register(request)));
+        return CommonResponse.onSuccess((memberService.register(request)));
     }
 
     @PostMapping("/reissue")
     @Operation(summary = "토큰 재발급", description = "토큰을 재발급합니다.")
-    public ApiResponse<MemberResponseDTO.reissue> reissue(
+    public CommonResponse<MemberResponseDTO.reissue> reissue(
             @RequestBody final MemberRequestDTO.reissue request
     ) {
-        return ApiResponse.onSuccess(memberService.reissue(request));
+        return CommonResponse.onSuccess(memberService.reissue(request));
     }
     @PostMapping("/login-tmp")
     @Operation(summary = "로그인 임시", description = "로그인 임시.")
-    public ApiResponse<MemberResponseDTO.registerMember> loginTemp(
+    public CommonResponse<MemberResponseDTO.registerMember> loginTemp(
             @RequestBody final MemberRequestDTO.loginMember request
     ){
-        return ApiResponse.onSuccess((memberService.login(request)));
+        return CommonResponse.onSuccess((memberService.login(request)));
     }
 
 
     @Operation(summary = "인증번호 요청 API ✔️️", description = "인증번호 요청 API입니다. 대시(-) 제외 전화번호 입력하시면 됩니다. ex) 01012345678 ")
     @ApiResponses({
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "OK 성공 , 인증번호 전송 완료"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "NCP200_1", description = "OK 성공 , 이미 회원가입된 전화번호입니다."),
+            @ApiResponse(responseCode = "200", description = "OK 성공 , 인증번호 전송 완료"),
+            @ApiResponse(responseCode = "NCP200_1", description = "OK 성공 , 이미 회원가입된 전화번호입니다."),
 
     })
     @PostMapping("/phone/sms")
-    public ApiResponse<MemberResponseDTO.checkSentSms> sendSms(@RequestBody MemberRequestDTO.SmsRequestDto request) throws JsonProcessingException, RestClientException, URISyntaxException, InvalidKeyException, NoSuchAlgorithmException, UnsupportedEncodingException {
+    public CommonResponse<MemberResponseDTO.checkSentSms> sendSms(@RequestBody MemberRequestDTO.SmsRequestDto request) throws JsonProcessingException, RestClientException, URISyntaxException, InvalidKeyException, NoSuchAlgorithmException, UnsupportedEncodingException {
         memberService.existsByPhoneNum(request.getTargetPhoneNum());
         MemberResponseDTO.checkSentSms authNumResultDto = ncpService.sendSms(request.getTargetPhoneNum());
-        return ApiResponse.onSuccess(authNumResultDto);
+        return CommonResponse.onSuccess(authNumResultDto);
     }
 
     //인증번호 검증
     @Operation(summary = "인증번호 검증 API ✔️️", description = "인증번호 검증 API입니다. 대시(-) 제외 전화번호와 인증번호 입력하시면 됩니다.")
     @ApiResponses({
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "OK 성공 , 인증 성공"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "NCP400_1", description = "BAD_REQUEST, 전화번호를 잘못 전달했거나, 인증요청을 하지않은 상태로 확인버튼을 누른 경우"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "NCP400_2", description = "BAD_REQUEST, 인증 번호가 옳지 않습니다."),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "NCP400_3", description = "BAD_REQUEST, 인증 시간(5분)이 지났습니다."),
+            @ApiResponse(responseCode = "200", description = "OK 성공 , 인증 성공"),
+            @ApiResponse(responseCode = "NCP400_1", description = "BAD_REQUEST, 전화번호를 잘못 전달했거나, 인증요청을 하지않은 상태로 확인버튼을 누른 경우"),
+            @ApiResponse(responseCode = "NCP400_2", description = "BAD_REQUEST, 인증 번호가 옳지 않습니다."),
+            @ApiResponse(responseCode = "NCP400_3", description = "BAD_REQUEST, 인증 시간(5분)이 지났습니다."),
     })
     @PostMapping("/phone/auth")
-    public ApiResponse<MemberResponseDTO.checkPhoneAuth> authPhoneNum(@RequestBody MemberRequestDTO.PhoneNumAuthDto request) {
+    public CommonResponse<MemberResponseDTO.checkPhoneAuth> authPhoneNum(@RequestBody MemberRequestDTO.PhoneNumAuthDto request) {
         MemberResponseDTO.checkPhoneAuth authNumResultDto = ncpService.authNumber(request.getAuthNum(), request.getPhoneNum());
-        return ApiResponse.onSuccess(authNumResultDto);
+        return CommonResponse.onSuccess(authNumResultDto);
     }
 }

--- a/src/main/java/org/example/tree/domain/notification/controller/NotificationController.java
+++ b/src/main/java/org/example/tree/domain/notification/controller/NotificationController.java
@@ -7,7 +7,7 @@ import org.example.tree.domain.member.entity.Member;
 import org.example.tree.domain.notification.dto.NotificationRequestDTO;
 import org.example.tree.domain.notification.dto.NotificationResponseDTO;
 import org.example.tree.domain.notification.service.NotificationService;
-import org.example.tree.global.common.ApiResponse;
+import org.example.tree.global.common.CommonResponse;
 import org.example.tree.global.security.handler.annotation.AuthMember;
 import org.springframework.web.bind.annotation.*;
 
@@ -22,27 +22,27 @@ public class NotificationController {
 
     @Operation(summary = "알림 생성 테스트")
     @PostMapping("/test")
-    public ApiResponse sendNotification(
+    public CommonResponse sendNotification(
             @RequestBody final NotificationRequestDTO.sendNotification request)
      {
          notificationService.sendNotification(request.getTitle(), request.getMessage(), request.getType(), request.getReceiverId());
-        return ApiResponse.onSuccess("success");
+        return CommonResponse.onSuccess("success");
     }
 
     @Operation(summary = "전체 알림 조회", description = "유저가 받은 알림들을 조회합니다.")
     @GetMapping
-    public ApiResponse<List<NotificationResponseDTO.getNotification>> getNotifications(
+    public CommonResponse<List<NotificationResponseDTO.getNotification>> getNotifications(
             @AuthMember @Parameter(hidden = true) Member member
     ) {
-        return ApiResponse.onSuccess(notificationService.getUserNotifications(member));
+        return CommonResponse.onSuccess(notificationService.getUserNotifications(member));
     }
 
     @Operation(summary = "특정 알림 조회", description = "유저가 받은 알림 중 하나를 조회합니다.")
     @GetMapping("/{notificationId}")
-    public ApiResponse<NotificationResponseDTO.getNotification> getNotification(
+    public CommonResponse<NotificationResponseDTO.getNotification> getNotification(
             @PathVariable final Long notificationId)
     {
-        return ApiResponse.onSuccess(notificationService.getNotification(notificationId));
+        return CommonResponse.onSuccess(notificationService.getNotification(notificationId));
     }
 
 }

--- a/src/main/java/org/example/tree/domain/post/controller/PostController.java
+++ b/src/main/java/org/example/tree/domain/post/controller/PostController.java
@@ -2,18 +2,14 @@ package org.example.tree.domain.post.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
-import io.swagger.v3.oas.annotations.Parameters;
-import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.example.tree.domain.member.entity.Member;
 import org.example.tree.domain.post.dto.PostRequestDTO;
 import org.example.tree.domain.post.dto.PostResponseDTO;
 import org.example.tree.domain.post.service.PostService;
-import org.example.tree.global.common.ApiResponse;
+import org.example.tree.global.common.CommonResponse;
 import org.example.tree.global.security.handler.annotation.AuthMember;
-import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.*;
-import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
 
@@ -24,64 +20,64 @@ public class PostController {
 
     @PostMapping("/trees/{treeId}/feed/posts")
     @Operation(summary = "게시글 작성", description = "게시글을 작성합니다.")
-    public ApiResponse<PostResponseDTO.createPost> createPost(
+    public CommonResponse<PostResponseDTO.createPost> createPost(
             @PathVariable final Long treeId,
             @RequestBody final PostRequestDTO.createPost request,
             @AuthMember @Parameter(hidden = true)  Member member
     ) throws Exception {
-        return ApiResponse.onSuccess(postService.createPost(treeId, request, member));
+        return CommonResponse.onSuccess(postService.createPost(treeId, request, member));
     }
 
     @GetMapping("/trees/{treeId}/feed")
     @Operation(summary = "피드 조회", description = "특정 트리하우스 속 피드를 불러옵니다.")
-    public ApiResponse<PostResponseDTO.getFeed> getFeed(
+    public CommonResponse<PostResponseDTO.getFeed> getFeed(
             @PathVariable final Long treeId,
             @AuthMember @Parameter(hidden = true)  Member member
     ) {
-        return ApiResponse.onSuccess(postService.getFeed(treeId, member));
+        return CommonResponse.onSuccess(postService.getFeed(treeId, member));
     }
 
     @GetMapping("/trees/{treeId}/feed/posts/{postId}")
     @Operation(summary = "게시글 조회", description = "특정 게시글을 조회합니다.")
-    public ApiResponse<PostResponseDTO.getPost> getPost(
+    public CommonResponse<PostResponseDTO.getPost> getPost(
             @PathVariable final Long treeId,
             @PathVariable final Long postId,
             @AuthMember @Parameter(hidden = true)  Member member
     )
     {
-        return ApiResponse.onSuccess(postService.getPost(treeId, postId, member));
+        return CommonResponse.onSuccess(postService.getPost(treeId, postId, member));
     }
 
     @GetMapping("/trees/{treeId}/feed/posts")
     @Operation(summary = "특정 멤버의 게시글 조회", description = "특정 멤버가 작성한 게시글 목록을 불러옵니다.")
-    public ApiResponse<List<PostResponseDTO.getPost>> getPosts(
+    public CommonResponse<List<PostResponseDTO.getPost>> getPosts(
             @PathVariable final Long treeId,
             @RequestParam(name = "member") final Long profileId,
             @AuthMember @Parameter(hidden = true) Member member
     ) {
-        return ApiResponse.onSuccess(postService.getTreePosts(treeId, profileId, member));
+        return CommonResponse.onSuccess(postService.getTreePosts(treeId, profileId, member));
     }
 
     @PatchMapping("/trees/{treeId}/feed/posts/{postId}")
     @Operation(summary = "게시글 수정", description = "게시글을 수정합니다.")
-    public ApiResponse updatePost(
+    public CommonResponse updatePost(
             @PathVariable final Long treeId,
             @PathVariable final Long postId,
             @AuthMember @Parameter(hidden = true) Member member,
             @RequestBody final PostRequestDTO.updatePost request
     ) {
         postService.updatePost(treeId, postId, request, member);
-        return ApiResponse.onSuccess("");
+        return CommonResponse.onSuccess("");
     }
 
     @DeleteMapping("/trees/{treeId}/feed/posts/{postId}")
     @Operation(summary = "게시글 삭제", description = "게시글을 삭제합니다.")
-    public ApiResponse deletePost(
+    public CommonResponse deletePost(
             @PathVariable final Long treeId,
             @PathVariable final Long postId,
             @AuthMember @Parameter(hidden = true) Member member
     ) {
         postService.deletePost(treeId, postId, member);
-        return ApiResponse.onSuccess("");
+        return CommonResponse.onSuccess("");
     }
 }

--- a/src/main/java/org/example/tree/domain/profile/controller/ProfileController.java
+++ b/src/main/java/org/example/tree/domain/profile/controller/ProfileController.java
@@ -6,12 +6,9 @@ import lombok.RequiredArgsConstructor;
 import org.example.tree.domain.member.entity.Member;
 import org.example.tree.domain.profile.dto.ProfileRequestDTO;
 import org.example.tree.domain.profile.service.ProfileService;
-import org.example.tree.domain.tree.dto.TreeRequestDTO;
-import org.example.tree.global.common.ApiResponse;
+import org.example.tree.global.common.CommonResponse;
 import org.example.tree.global.security.handler.annotation.AuthMember;
-import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.*;
-import org.springframework.web.multipart.MultipartFile;
 
 @RestController
 @RequiredArgsConstructor
@@ -20,37 +17,37 @@ public class ProfileController {
 
     @PostMapping("/treehouses/owner/register")
     @Operation(summary = "트리하우스 설립자 등록", description = "트리하우스의 설립자(Owner)로 등록합니다.")
-    public ApiResponse registerTreehouseOwner(
+    public CommonResponse registerTreehouseOwner(
             @RequestBody ProfileRequestDTO.ownerProfile request,
             @AuthMember @Parameter(hidden = true) Member member
     ) throws Exception {
-        return ApiResponse.onSuccess(profileService.ownerProfile(request, member));
+        return CommonResponse.onSuccess(profileService.ownerProfile(request, member));
     }
 
     @PostMapping("/treehouses/members/register")
     @Operation(summary = "트리하우스 멤버 가입", description = "트리하우스의 멤버로 등록합니다.")
-    public ApiResponse registerTreehouseMember(
+    public CommonResponse registerTreehouseMember(
             @RequestBody ProfileRequestDTO.createProfile request,
             @AuthMember @Parameter(hidden = true) Member member
             ) throws Exception {
-        return ApiResponse.onSuccess(profileService.createProfile(request, member));
+        return CommonResponse.onSuccess(profileService.createProfile(request, member));
     }
 
     @GetMapping("/treehouses/{treeId}/members/{profileId}") //프로필 조회
     @Operation(summary = "멤버 프로필 조회", description = "트리하우스 속 특정 멤버의 프로필을 조회합니다.")
-    public ApiResponse getProfileDetails(
+    public CommonResponse getProfileDetails(
             @AuthMember @Parameter(hidden = true) Member member,
             @PathVariable Long treeId,
             @PathVariable Long profileId) {
-        return ApiResponse.onSuccess(profileService.getProfileDetails(member, profileId));
+        return CommonResponse.onSuccess(profileService.getProfileDetails(member, profileId));
     }
 
     @GetMapping("/treehouses/{treeId}/myProfile") //내 프로필 조회
     @Operation(summary = "내 프로필 조회", description = "트리하우스 속 내 프로필을 조회합니다.")
-    public ApiResponse getMyProfile(
+    public CommonResponse getMyProfile(
             @AuthMember @Parameter(hidden = true) Member member,
             @PathVariable Long treeId
     ) {
-        return ApiResponse.onSuccess(profileService.getMyProfile(member, treeId));
+        return CommonResponse.onSuccess(profileService.getMyProfile(member, treeId));
     }
 }

--- a/src/main/java/org/example/tree/domain/reaction/controller/ReactionController.java
+++ b/src/main/java/org/example/tree/domain/reaction/controller/ReactionController.java
@@ -7,7 +7,7 @@ import org.example.tree.domain.member.entity.Member;
 import org.example.tree.domain.reaction.dto.ReactionRequestDTO;
 import org.example.tree.domain.reaction.dto.ReactionResponseDTO;
 import org.example.tree.domain.reaction.service.ReactionService;
-import org.example.tree.global.common.ApiResponse;
+import org.example.tree.global.common.CommonResponse;
 import org.example.tree.global.security.handler.annotation.AuthMember;
 import org.springframework.web.bind.annotation.*;
 
@@ -19,35 +19,35 @@ public class ReactionController {
 
     @PostMapping("/trees/{treeId}/feed/posts/{postId}/reaction")
     @Operation(summary = "게시글 리액션", description = "게시글에 리액션을 추가합니다.")
-    public ApiResponse<ReactionResponseDTO.addReaction> createPostReaction(
+    public CommonResponse<ReactionResponseDTO.addReaction> createPostReaction(
             @PathVariable Long treeId,
             @PathVariable Long postId,
             @RequestBody ReactionRequestDTO.createReaction request,
             @AuthMember @Parameter(hidden = true) Member member
             ) {
-        return ApiResponse.onSuccess(reactionService.reactToPost(treeId, postId, request, member));
+        return CommonResponse.onSuccess(reactionService.reactToPost(treeId, postId, request, member));
     }
 
     @PostMapping("/trees/{treeId}/feed/comments/{commentId}/reaction")
     @Operation(summary = "댓글 리액션", description = "댓글에 리액션을 추가합니다.")
-    public ApiResponse<ReactionResponseDTO.addReaction> createCommentReaction(
+    public CommonResponse<ReactionResponseDTO.addReaction> createCommentReaction(
             @PathVariable Long treeId,
             @PathVariable Long commentId,
             @RequestBody ReactionRequestDTO.createReaction request,
             @AuthMember @Parameter(hidden = true) Member member
     ) {
-        return ApiResponse.onSuccess(reactionService.reactToComment(treeId, commentId, request, member));
+        return CommonResponse.onSuccess(reactionService.reactToComment(treeId, commentId, request, member));
     }
 
     @PostMapping("/trees/{treeId}/feed/replies/{replyId}/reaction")
     @Operation(summary = "답글 리액션", description = "답글에 리액션을 추가합니다.")
-    public ApiResponse<ReactionResponseDTO.addReaction> createReplyReaction(
+    public CommonResponse<ReactionResponseDTO.addReaction> createReplyReaction(
             @PathVariable Long treeId,
             @PathVariable Long replyId,
             @RequestBody ReactionRequestDTO.createReaction request,
             @AuthMember @Parameter(hidden = true) Member member
             ) {
-        return ApiResponse.onSuccess(reactionService.reactToReply(treeId, replyId, request, member));
+        return CommonResponse.onSuccess(reactionService.reactToReply(treeId, replyId, request, member));
     }
 
 

--- a/src/main/java/org/example/tree/domain/tree/controller/TreeController.java
+++ b/src/main/java/org/example/tree/domain/tree/controller/TreeController.java
@@ -7,7 +7,7 @@ import org.example.tree.domain.member.entity.Member;
 import org.example.tree.domain.tree.dto.TreeRequestDTO;
 import org.example.tree.domain.tree.dto.TreeResponseDTO;
 import org.example.tree.domain.tree.service.TreeService;
-import org.example.tree.global.common.ApiResponse;
+import org.example.tree.global.common.CommonResponse;
 import org.example.tree.global.security.handler.annotation.AuthMember;
 import org.springframework.web.bind.annotation.*;
 
@@ -21,28 +21,28 @@ public class TreeController {
 
     @Operation(summary = "트리하우스 등록")
     @PostMapping("/register")
-    public ApiResponse createTree(
+    public CommonResponse createTree(
             @RequestBody TreeRequestDTO.createTree request
     ) {
         treeService.createTree(request);
-        return ApiResponse.onSuccess("");
+        return CommonResponse.onSuccess("");
     }
 
     @Operation(summary = "트리하우스 조회")
     @GetMapping
-    public ApiResponse<List<TreeResponseDTO.getTree>> getTrees(
+    public CommonResponse<List<TreeResponseDTO.getTree>> getTrees(
             @AuthMember @Parameter(hidden = true) Member member
     ) {
-         return ApiResponse.onSuccess(treeService.getTrees(member));
+         return CommonResponse.onSuccess(treeService.getTrees(member));
     }
 
     @Operation(summary = "트리하우스 위치 변경")
     @PostMapping("/{treeId}")
-    public ApiResponse<TreeResponseDTO.shiftTree> shiftTree(
+    public CommonResponse<TreeResponseDTO.shiftTree> shiftTree(
             @AuthMember @Parameter(hidden = true) Member member,
             @PathVariable final Long treeId
     ) {
-        return ApiResponse.onSuccess(treeService.shiftTree(treeId, member));
+        return CommonResponse.onSuccess(treeService.shiftTree(treeId, member));
     }
 
 }

--- a/src/main/java/org/example/tree/global/common/CommonResponse.java
+++ b/src/main/java/org/example/tree/global/common/CommonResponse.java
@@ -1,7 +1,6 @@
 package org.example.tree.global.common;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
-import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -10,14 +9,13 @@ import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
-import org.example.tree.global.exception.GlobalErrorCode;
 
 import java.time.LocalDateTime;
 
 @Getter
 @AllArgsConstructor
 @JsonPropertyOrder( {"isSuccess", "code", "message", "data"} )
-public class ApiResponse<T> {
+public class CommonResponse<T> {
     @Override
     public String toString() {
         try {
@@ -48,13 +46,13 @@ public class ApiResponse<T> {
 
     // 성공한 경우 응답 생성
 
-    public static <T> ApiResponse<T> onSuccess(T data){
-        return new ApiResponse<>(true, "200" , "요청에 성공하였습니다.", LocalDateTime.now(), data);
+    public static <T> CommonResponse<T> onSuccess(T data){
+        return new CommonResponse<>(true, "200" , "요청에 성공하였습니다.", LocalDateTime.now(), data);
     }
 
     // 실패한 경우 응답 생성
-    public static <T> ApiResponse<T> onFailure(String code, String message, T data){
-        return new ApiResponse<>(false,code, message, LocalDateTime.now(), data);
+    public static <T> CommonResponse<T> onFailure(String code, String message, T data){
+        return new CommonResponse<>(false,code, message, LocalDateTime.now(), data);
     }
 
 }

--- a/src/main/java/org/example/tree/global/exception/GeneralExceptionHandler.java
+++ b/src/main/java/org/example/tree/global/exception/GeneralExceptionHandler.java
@@ -4,7 +4,7 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.ConstraintViolationException;
 import jakarta.validation.constraints.NotNull;
 import lombok.extern.slf4j.Slf4j;
-import org.example.tree.global.common.ApiResponse;
+import org.example.tree.global.common.CommonResponse;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.HttpStatusCode;
@@ -105,8 +105,8 @@ public class GeneralExceptionHandler extends ResponseEntityExceptionHandler {
     private ResponseEntity<Object> handleExceptionInternal(
             Exception e, ErrorReasonDTO reason, HttpHeaders headers, HttpServletRequest request) {
 
-        ApiResponse<Object> body =
-                ApiResponse.onFailure(reason.getCode(), reason.getMessage(), null);
+        CommonResponse<Object> body =
+                CommonResponse.onFailure(reason.getCode(), reason.getMessage(), null);
         e.printStackTrace();
 
         WebRequest webRequest = new ServletWebRequest(request);
@@ -121,8 +121,8 @@ public class GeneralExceptionHandler extends ResponseEntityExceptionHandler {
             HttpStatus status,
             WebRequest request,
             String errorPoint) {
-        ApiResponse<Object> body =
-                ApiResponse.onFailure(errorCode.getCode(), errorCode.getMessage(), errorPoint);
+        CommonResponse<Object> body =
+                CommonResponse.onFailure(errorCode.getCode(), errorCode.getMessage(), errorPoint);
         return super.handleExceptionInternal(e, body, headers, status, request);
     }
 
@@ -132,15 +132,15 @@ public class GeneralExceptionHandler extends ResponseEntityExceptionHandler {
             GlobalErrorCode errorCode,
             WebRequest request,
             Map<String, String> errorArgs) {
-        ApiResponse<Object> body =
-                ApiResponse.onFailure(errorCode.getCode(), errorCode.getMessage(), errorArgs);
+        CommonResponse<Object> body =
+                CommonResponse.onFailure(errorCode.getCode(), errorCode.getMessage(), errorArgs);
         return super.handleExceptionInternal(e, body, headers, errorCode.getHttpStatus(), request);
     }
 
     private ResponseEntity<Object> handleExceptionInternalConstraint(
             Exception e, GlobalErrorCode errorCode, HttpHeaders headers, WebRequest request) {
-        ApiResponse<Object> body =
-                ApiResponse.onFailure(errorCode.getCode(), errorCode.getMessage(), null);
+        CommonResponse<Object> body =
+                CommonResponse.onFailure(errorCode.getCode(), errorCode.getMessage(), null);
         return super.handleExceptionInternal(e, body, headers, errorCode.getHttpStatus(), request);
     }
 

--- a/src/main/java/org/example/tree/global/security/filter/JwtAuthFilter.java
+++ b/src/main/java/org/example/tree/global/security/filter/JwtAuthFilter.java
@@ -1,18 +1,15 @@
 package org.example.tree.global.security.filter;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import io.jsonwebtoken.Claims;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.example.tree.global.common.ApiResponse;
+import org.example.tree.global.common.CommonResponse;
 import org.example.tree.global.exception.AuthErrorCode;
-import org.example.tree.global.exception.GlobalErrorCode;
 import org.example.tree.global.security.provider.TokenProvider;
-import org.springframework.http.HttpStatus;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.util.StringUtils;
@@ -72,7 +69,7 @@ public class JwtAuthFilter extends OncePerRequestFilter {
             // AuthErrorCode로부터 code와 message 추출
             String code = errorCode.getCode();
             String message = errorCode.getMessage();
-            String json = new ObjectMapper().writeValueAsString(ApiResponse.onFailure(code, message, null)); // ApiResponse 객체를 JSON으로 변환
+            String json = new ObjectMapper().writeValueAsString(CommonResponse.onFailure(code, message, null)); // ApiResponse 객체를 JSON으로 변환
             response.getWriter().write(json);
         } catch (Exception e) {
             log.error(e.getMessage());

--- a/src/main/java/org/example/tree/global/security/handler/JwtAccessDeniedHandler.java
+++ b/src/main/java/org/example/tree/global/security/handler/JwtAccessDeniedHandler.java
@@ -3,9 +3,8 @@ package org.example.tree.global.security.handler;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
-import org.example.tree.global.common.ApiResponse;
+import org.example.tree.global.common.CommonResponse;
 import org.example.tree.global.exception.AuthErrorCode;
-import org.example.tree.global.exception.GlobalErrorCode;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.security.access.AccessDeniedException;
@@ -32,7 +31,7 @@ public class JwtAccessDeniedHandler implements AccessDeniedHandler {
         // AuthErrorCode.AUTHENTICATION_DENIED enum에서 코드와 메시지를 얻음
         String code = AuthErrorCode.AUTHENTICATION_DENIED.getCode();
         String message = AuthErrorCode.AUTHENTICATION_DENIED.getMessage();
-        ApiResponse<String> apiErrorResult = ApiResponse.onFailure(code, message, null);
+        CommonResponse<String> apiErrorResult = CommonResponse.onFailure(code, message, null);
         writer.write(apiErrorResult.toString());
         writer.flush();
         writer.close();

--- a/src/main/java/org/example/tree/global/security/handler/JwtAuthenticationEntryPoint.java
+++ b/src/main/java/org/example/tree/global/security/handler/JwtAuthenticationEntryPoint.java
@@ -3,9 +3,8 @@ package org.example.tree.global.security.handler;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
-import org.example.tree.global.common.ApiResponse;
+import org.example.tree.global.common.CommonResponse;
 import org.example.tree.global.exception.AuthErrorCode;
-import org.example.tree.global.exception.GlobalErrorCode;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.security.core.AuthenticationException;
@@ -32,7 +31,7 @@ public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
         // AuthErrorCode.AUTHENTICATION_REQUIRED enum에서 코드와 메시지를 얻음
         String code = AuthErrorCode.AUTHENTICATION_REQUIRED.getCode();
         String message = AuthErrorCode.AUTHENTICATION_REQUIRED.getMessage();
-        ApiResponse<String> apiErrorResult = ApiResponse.onFailure(code, message, null);
+        CommonResponse<String> apiErrorResult = CommonResponse.onFailure(code, message, null);
 
         writer.write(apiErrorResult.toString());
         writer.flush();

--- a/src/main/java/org/example/tree/global/security/handler/JwtAuthenticationExceptionHandler.java
+++ b/src/main/java/org/example/tree/global/security/handler/JwtAuthenticationExceptionHandler.java
@@ -4,11 +4,9 @@ import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
-import org.example.tree.global.common.ApiResponse;
+import org.example.tree.global.common.CommonResponse;
 import org.example.tree.global.exception.AuthErrorCode;
-import org.example.tree.global.exception.GlobalErrorCode;
 import org.example.tree.global.exception.JwtAuthenticationException;
-import org.example.tree.global.exception.JwtReissueException;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.filter.OncePerRequestFilter;
 
@@ -30,7 +28,7 @@ public class JwtAuthenticationExceptionHandler extends OncePerRequestFilter {
             PrintWriter writer = response.getWriter();
             String errorCodeName = authException.getMessage();
             AuthErrorCode errorCode = AuthErrorCode.valueOf(errorCodeName);
-            ApiResponse<String> apiErrorResult = ApiResponse.onFailure(errorCode.getCode(),errorCode.getMessage(), null);
+            CommonResponse<String> apiErrorResult = CommonResponse.onFailure(errorCode.getCode(),errorCode.getMessage(), null);
 
             writer.write(apiErrorResult.toString());
             writer.flush();


### PR DESCRIPTION
# 🚀 개요
<!-- 이 PR을 간략하게 설명해주세요 -->
Swagger 관련 어노테이션과의 호환을 위해 `ApiResponse` 클래스의 이름을 `CommonResponse`로 변경

## 🔍 변경사항
<!-- 이 PR로 인해 바뀌게 되는 것들을 목록으로 적어주세요. -->
- `ApiResponse` 클래스의 이름을 `CommonResponse`로 변경
- `ApiResponse`를 호출하는 모든 컨트롤러에서의 이름도 변경


## ⏳ 작업 내용
- [x] `ApiResponse` 클래스의 이름을 `CommonResponse`로 변경
- [x] `ApiResponse`를 호출하는 모든 컨트롤러에서의 이름도 변경
- [x] `MemberController`의 `@ApiResponse`에 해당하는 부분 import 하도록 변경

### 📝 논의사항
<!-- 이 PR에 대한 논의하고 싶은 사항이나, 더 해야할 작업, 리뷰어에게 특별히 확인 요청하고 싶은 부분 등을 적어주세요. -->

